### PR TITLE
chore: Clean up local tracking directories

### DIFF
--- a/.branch-metadata.json
+++ b/.branch-metadata.json
@@ -1,0 +1,9 @@
+{
+  "main": {
+    "last_sync": {
+      "commit_hash": "1c03f4a12e3c6280ded4bbf5c1f26a4719e500b7",
+      "commit_message": "Merge pull request #4 from tzervas/code-review-fixes",
+      "sync_date": "2024-01-09"
+    }
+  }
+}

--- a/.branch-metadata.yaml
+++ b/.branch-metadata.yaml
@@ -1,0 +1,10 @@
+branches:
+  refactor/oauth-event-handlers:
+    purpose: Refactor OAuth event handler implementations
+    status: Active development
+    last_sync: $(date +"%Y-%m-%d")
+    sync_target: origin/main
+    description: >
+      Branch dedicated to refactoring OAuth event handlers to improve code organization
+      and maintainability. Focuses on restructuring the event handling logic for OAuth
+      authentication flows.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,10 @@ on:
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.12"]
 
     steps:
@@ -25,36 +26,38 @@ jobs:
 
     - name: Install uv
       run: |
-        curl -LsSf https://astral.sh/uv/install.sh | sh
-        echo "$HOME/.cargo/bin" >> $GITHUB_PATH # Older uv versions, $HOME/.uv/bin for newer
-        echo "$HOME/.uv/bin" >> $GITHUB_PATH    # Ensure new path is included
+        if [ "$RUNNER_OS" == "Linux" ] || [ "$RUNNER_OS" == "macOS" ]; then
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH # Older uv versions
+          echo "$HOME/.uv/bin" >> $GITHUB_PATH    # Newer versions
+        elif [ "$RUNNER_OS" == "Windows" ]; then
+          curl.exe -LsSf https://astral.sh/uv/install.ps1 -o install.ps1
+          powershell.exe -File install.ps1
+          echo "$HOME\.cargo\bin" >> $GITHUB_PATH # Older uv versions
+          echo "$HOME\.uv\bin" >> $GITHUB_PATH    # Newer versions
+        fi
         uv --version # Verify installation
 
     - name: Install dependencies using uv
       run: |
         uv pip install --system --upgrade pip # Ensure pip is there for uv's pip backend if needed
         uv venv .venv --python ${{ matrix.python-version }}
-        source .venv/bin/activate
         uv pip install --editable ".[dev]"
 
     - name: Lint with Ruff
       run: |
-        source .venv/bin/activate
         uv run ruff check .
 
     - name: Format with Black (check only)
       run: |
-        source .venv/bin/activate
         uv run black --check .
 
     - name: Type check with MyPy
       run: |
-        source .venv/bin/activate
         uv run mypy src tests
 
     - name: Test with Pytest and generate coverage
       run: |
-        source .venv/bin/activate
         uv run pytest --cov=src/mcp_vacuum --cov-report=xml --cov-report=term-missing tests/
 
     - name: Upload coverage reports to Codecov

--- a/.github/workflows/setup-uv.yml
+++ b/.github/workflows/setup-uv.yml
@@ -1,0 +1,25 @@
+name: Setup UV Package Manager
+
+on: [workflow_dispatch]
+
+jobs:
+  setup-uv:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        
+    steps:
+      - name: Install UV (Unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh -s -- --prefix $HOME/.uv
+          echo "$HOME/.cargo/bin:$HOME/.uv/bin" >> $GITHUB_PATH
+
+      - name: Install UV (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh -s -- --prefix $HOME/.uv
+          echo "$Env:USERPROFILE\.uv\bin" >> $env:GITHUB_PATH

--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,5 @@ secrets/
 
 # ignore internal docs
 # docs/*.pdf
+
+.project-trackers/

--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,7 @@ secrets/
 # docs/*.pdf
 
 .project-trackers/
+
+# Internal documentation and tracking (moved to mcp-vacuum-internal)
+.local/
+.metadata/

--- a/.local/branch-metadata.json
+++ b/.local/branch-metadata.json
@@ -1,0 +1,6 @@
+{
+  "branches": [],
+  "last_updated": "",
+  "metadata_schema_version": "1.0",
+  "active_branch": ""
+}

--- a/.local/doc-index.json
+++ b/.local/doc-index.json
@@ -1,0 +1,13 @@
+{
+  "index_schema_version": "1.0",
+  "documentation_entries": [],
+  "last_indexed": "",
+  "documentation_paths": [
+    "docs/",
+    "README.md"
+  ],
+  "metadata": {
+    "indexed_file_types": [".md", ".rst", ".txt"],
+    "exclude_patterns": ["node_modules/", "dist/", "build/"]
+  }
+}

--- a/.local/extract_function_metadata.py
+++ b/.local/extract_function_metadata.py
@@ -1,0 +1,117 @@
+import json
+import os
+import subprocess
+from typing import Dict, List, Optional
+import ast
+import logging
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+class FunctionVisitor(ast.NodeVisitor):
+    def __init__(self):
+        self.functions = []
+        
+    def visit_FunctionDef(self, node):
+        # Extract function signature
+        args = []
+        for arg in node.args.args:
+            arg_info = {
+                'name': arg.arg,
+                'type': ast.unparse(arg.annotation) if hasattr(arg, 'annotation') and arg.annotation else None
+            }
+            args.append(arg_info)
+            
+        # Extract return type
+        return_type = ast.unparse(node.returns) if node.returns else None
+        
+        # Extract docstring
+        docstring = ast.get_docstring(node)
+        
+        # Extract dependencies from imports
+        dependencies = []
+        for ancestor in ast.walk(node):
+            if isinstance(ancestor, ast.Import):
+                for name in ancestor.names:
+                    dependencies.append(name.name)
+            elif isinstance(ancestor, ast.ImportFrom):
+                dependencies.append(ancestor.module)
+        
+        function_info = {
+            'name': node.name,
+            'signature': {
+                'args': args,
+                'return_type': return_type
+            },
+            'docstring': docstring,
+            'dependencies': list(set(dependencies))
+        }
+        
+        self.functions.append(function_info)
+        
+        self.generic_visit(node)
+
+def extract_functions_from_file(file_path: str) -> List[Dict]:
+    try:
+        with open(file_path, 'r', encoding='utf-8') as f:
+            tree = ast.parse(f.read())
+            
+        visitor = FunctionVisitor()
+        visitor.visit(tree)
+        return visitor.functions
+    except Exception as e:
+        logger.error(f"Error processing {file_path}: {str(e)}")
+        return []
+
+def get_python_files() -> List[str]:
+    result = subprocess.run(['git', 'ls-files', '*.py'], 
+                          capture_output=True, 
+                          text=True)
+    return result.stdout.strip().split('\n')
+
+def extract_branch_metadata() -> Dict:
+    metadata = {}
+    
+    # Get all branches
+    result = subprocess.run(['git', 'branch', '--no-color'], 
+                          capture_output=True, 
+                          text=True)
+    branches = [b.strip().replace('* ', '') for b in result.stdout.split('\n') if b.strip()]
+    
+    for branch in branches:
+        logger.info(f"Processing branch: {branch}")
+        
+        # Checkout branch
+        subprocess.run(['git', 'checkout', branch], 
+                      capture_output=True)
+        
+        branch_data = {}
+        python_files = get_python_files()
+        
+        for file_path in python_files:
+            if file_path and os.path.exists(file_path):
+                functions = extract_functions_from_file(file_path)
+                if functions:
+                    branch_data[file_path] = functions
+        
+        if branch_data:
+            metadata[branch] = branch_data
+    
+    # Return to original branch
+    subprocess.run(['git', 'checkout', '-'], capture_output=True)
+    
+    return metadata
+
+def main():
+    os.makedirs('.local', exist_ok=True)
+    
+    metadata = extract_branch_metadata()
+    
+    output_path = '.local/function-metadata.json'
+    with open(output_path, 'w') as f:
+        json.dump(metadata, f, indent=2)
+    
+    logger.info(f"Function metadata written to {output_path}")
+
+if __name__ == '__main__':
+    main()

--- a/.local/function-metadata.json
+++ b/.local/function-metadata.json
@@ -1,0 +1,7240 @@
+{
+  "code-review-fixes": {
+    "src/mcp_vacuum/__main__.py": [
+      {
+        "name": "cli",
+        "signature": {
+          "args": [
+            {
+              "name": "ctx",
+              "type": "click.Context"
+            },
+            {
+              "name": "config_file",
+              "type": "str | None"
+            },
+            {
+              "name": "log_level",
+              "type": "str | None"
+            },
+            {
+              "name": "log_format",
+              "type": "str | None"
+            }
+          ],
+          "return_type": "None"
+        },
+        "docstring": "MCP Vacuum - Discovers MCP servers, authenticates, and converts schemas.",
+        "dependencies": []
+      },
+      {
+        "name": "discover",
+        "signature": {
+          "args": [
+            {
+              "name": "ctx",
+              "type": "click.Context"
+            },
+            {
+              "name": "networks",
+              "type": "list[str]"
+            },
+            {
+              "name": "output_file",
+              "type": "str | None"
+            }
+          ],
+          "return_type": "None"
+        },
+        "docstring": "Discovers MCP servers, authenticates, and generates Kagent schemas.",
+        "dependencies": []
+      },
+      {
+        "name": "version",
+        "signature": {
+          "args": [
+            {
+              "name": "ctx",
+              "type": "click.Context"
+            }
+          ],
+          "return_type": "None"
+        },
+        "docstring": "Show version information.",
+        "dependencies": []
+      },
+      {
+        "name": "config_show",
+        "signature": {
+          "args": [
+            {
+              "name": "ctx",
+              "type": "click.Context"
+            }
+          ],
+          "return_type": "None"
+        },
+        "docstring": "Show current configuration.",
+        "dependencies": []
+      }
+    ],
+    "src/mcp_vacuum/adk/auth_agent.py": [
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "server_id",
+              "type": "str"
+            },
+            {
+              "name": "success",
+              "type": "bool"
+            },
+            {
+              "name": "auth_data",
+              "type": "dict[str, Any] | None"
+            },
+            {
+              "name": "error_message",
+              "type": "str | None"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "__repr__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "app_config",
+              "type": "Config"
+            },
+            {
+              "name": "parent_logger",
+              "type": "structlog.BoundLogger"
+            },
+            {
+              "name": "output_queue",
+              "type": "asyncio.Queue"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      }
+    ],
+    "src/mcp_vacuum/adk/base.py": [
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "agent_name",
+              "type": "str"
+            },
+            {
+              "name": "app_config",
+              "type": "Config"
+            },
+            {
+              "name": "parent_logger",
+              "type": "structlog.BoundLogger | None"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": "Args:\n    agent_name: A unique name for this agent instance.\n    app_config: The global application configuration.\n    parent_logger: Optional logger from a parent agent for hierarchical\n                   logging.\n    **kwargs: Additional arguments for the underlying ADK BaseAgent.",
+        "dependencies": []
+      }
+    ],
+    "src/mcp_vacuum/adk/conversion_agent.py": [
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "server_id",
+              "type": "str"
+            },
+            {
+              "name": "success",
+              "type": "bool"
+            },
+            {
+              "name": "kagent_tools_schemas",
+              "type": "list[KagentTool] | None"
+            },
+            {
+              "name": "original_tool_count",
+              "type": "int | None"
+            },
+            {
+              "name": "error_message",
+              "type": "str | None"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "__repr__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "app_config",
+              "type": "Config"
+            },
+            {
+              "name": "parent_logger",
+              "type": "structlog.BoundLogger"
+            },
+            {
+              "name": "output_queue",
+              "type": "asyncio.Queue"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      }
+    ],
+    "src/mcp_vacuum/adk/discovery_agent.py": [
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "server_info",
+              "type": "MCPServiceRecord"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "__repr__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "app_config",
+              "type": "Config"
+            },
+            {
+              "name": "parent_logger",
+              "type": "structlog.BoundLogger"
+            },
+            {
+              "name": "output_queue",
+              "type": "asyncio.Queue"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      }
+    ],
+    "src/mcp_vacuum/adk/mcp_client_agent.py": [
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "app_config",
+              "type": "Config"
+            },
+            {
+              "name": "parent_logger",
+              "type": "structlog.BoundLogger"
+            },
+            {
+              "name": "auth_agent_ref",
+              "type": "AuthenticationAgent"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      }
+    ],
+    "src/mcp_vacuum/adk/orchestration_agent.py": [
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "target_networks",
+              "type": "list[str] | None"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "server_id",
+              "type": "str"
+            },
+            {
+              "name": "server_info",
+              "type": "dict[str, Any]"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "server_id",
+              "type": "str"
+            },
+            {
+              "name": "mcp_tools_data",
+              "type": "list[dict[str, Any]]"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "app_config",
+              "type": "Config"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "_setup_global_logging",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": "None"
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "get_summary",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": "dict[str, int]"
+        },
+        "docstring": null,
+        "dependencies": []
+      }
+    ],
+    "src/mcp_vacuum/auth/dynamic_registration.py": [
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "app_config",
+              "type": "Config"
+            },
+            {
+              "name": "session",
+              "type": "aiohttp.ClientSession | None"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": "Initializes the DynamicClientRegistrar.\n\nArgs:\n    app_config: Global application configuration.\n    session: An optional shared aiohttp.ClientSession.",
+        "dependencies": []
+      }
+    ],
+    "src/mcp_vacuum/auth/oauth_client.py": [
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "client_config",
+              "type": "OAuth2ClientConfig"
+            },
+            {
+              "name": "app_config",
+              "type": "Config"
+            },
+            {
+              "name": "session",
+              "type": "aiohttp.ClientSession | None"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": "Initializes the OAuth2 client.\n\nArgs:\n    client_config: Configuration specific to this OAuth client instance\n                   (client_id, endpoints, etc.).\n    app_config: Global application configuration, used for HTTP client\n                settings.\n    session: An optional shared aiohttp.ClientSession. If None, one\n             will be created.",
+        "dependencies": []
+      },
+      {
+        "name": "create_authorization_url",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "state",
+              "type": "str"
+            },
+            {
+              "name": "pkce",
+              "type": "PKCEChallenge"
+            },
+            {
+              "name": "extra_params",
+              "type": "dict[str, str] | None"
+            }
+          ],
+          "return_type": "tuple[str, str, str]"
+        },
+        "docstring": "Creates the authorization URL to redirect the user to.\n\nArgs:\nstate: An opaque value used to maintain state between the request and\n       callback.\npkce: The PKCEChallenge object containing verifier, challenge, and\n      method.\nextra_params: Additional query parameters to include in the\n              authorization request.\n\nReturns:\n    A tuple containing:\n    - The full authorization URL.\n    - The state parameter used.\n    - The PKCE code verifier.",
+        "dependencies": []
+      }
+    ],
+    "src/mcp_vacuum/auth/pkce.py": [
+      {
+        "name": "generate_pkce_challenge_pair",
+        "signature": {
+          "args": [
+            {
+              "name": "code_challenge_method",
+              "type": "str"
+            }
+          ],
+          "return_type": "PKCEChallenge"
+        },
+        "docstring": "Generates a PKCE code_verifier and a corresponding code_challenge.\n\nArgs:\n    code_challenge_method: The method used to generate the challenge.\n                           Currently supports \"S256\" or \"plain\".\n\nReturns:\n    A PKCEChallenge object containing the verifier, challenge, and method.\n\nRaises:\n    ValueError: If an unsupported code_challenge_method is provided.",
+        "dependencies": []
+      }
+    ],
+    "src/mcp_vacuum/auth/token_manager.py": [
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "app_config",
+              "type": "Config"
+            },
+            {
+              "name": "token_storage",
+              "type": "BaseTokenStorage | None"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": "Initializes the TokenManager.\n\nArgs:\n    app_config: The global application configuration.\n    token_storage: An instance of a token storage backend. If None,\n                   one will be created based on app_config.auth.",
+        "dependencies": []
+      }
+    ],
+    "src/mcp_vacuum/auth/token_storage.py": [
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "auth_config",
+              "type": "AuthConfig"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "_get_key",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "server_id",
+              "type": "str"
+            },
+            {
+              "name": "suffix",
+              "type": "str"
+            }
+          ],
+          "return_type": "str"
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "auth_config",
+              "type": "AuthConfig"
+            },
+            {
+              "name": "encryption_key",
+              "type": "bytes"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "derive_key_from_password",
+        "signature": {
+          "args": [
+            {
+              "name": "password",
+              "type": "str"
+            },
+            {
+              "name": "salt",
+              "type": "bytes"
+            }
+          ],
+          "return_type": "bytes"
+        },
+        "docstring": "Derives an encryption key from a password using PBKDF2HMAC-SHA256.",
+        "dependencies": []
+      },
+      {
+        "name": "get_token_storage",
+        "signature": {
+          "args": [
+            {
+              "name": "auth_config",
+              "type": "AuthConfig"
+            }
+          ],
+          "return_type": "BaseTokenStorage"
+        },
+        "docstring": "Factory function to get a token storage instance based on configuration.\nRequires ENCRYPTION_KEY_ENV_VAR or similar for EncryptedFileTokenStorage if\nused.",
+        "dependencies": []
+      }
+    ],
+    "src/mcp_vacuum/config.py": [
+      {
+        "name": "from_file",
+        "signature": {
+          "args": [
+            {
+              "name": "cls",
+              "type": null
+            },
+            {
+              "name": "file_path",
+              "type": "Path"
+            }
+          ],
+          "return_type": "'Config'"
+        },
+        "docstring": "Create configuration strictly from a JSON file.\nNote: This does not layer with environment variables. For layered loading,\npydantic-settings offers other mechanisms if env_file in SettingsConfigDict is not sufficient.",
+        "dependencies": []
+      }
+    ],
+    "src/mcp_vacuum/discovery/discovery_service.py": [
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "app_config",
+              "type": "Config"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "get_cached_server",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "server_id",
+              "type": "str"
+            }
+          ],
+          "return_type": "MCPServiceRecord | None"
+        },
+        "docstring": "Returns a cached MCPServiceRecord if found and not expired.",
+        "dependencies": []
+      },
+      {
+        "name": "get_all_cached_servers",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": "list[MCPServiceRecord]"
+        },
+        "docstring": "Returns all currently cached and valid (non-expired TTL) MCPServiceRecords.",
+        "dependencies": []
+      }
+    ],
+    "src/mcp_vacuum/mcp_client/base_client.py": [
+      {
+        "name": "generate_jsonrpc_request",
+        "signature": {
+          "args": [
+            {
+              "name": "method",
+              "type": "str"
+            },
+            {
+              "name": "params",
+              "type": "dict[str, Any] | None"
+            },
+            {
+              "name": "request_id",
+              "type": "str | int | None"
+            }
+          ],
+          "return_type": "dict[str, Any]"
+        },
+        "docstring": "Generates a JSONRPC 2.0 request dictionary.",
+        "dependencies": []
+      },
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "service_record",
+              "type": "MCPServiceRecord"
+            },
+            {
+              "name": "config",
+              "type": "Config"
+            },
+            {
+              "name": "aiohttp_session",
+              "type": "aiohttp.ClientSession | None"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "get_session",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": "aiohttp.ClientSession | None"
+        },
+        "docstring": "Returns the aiohttp session if used by the client (primarily for HTTP-based transports).",
+        "dependencies": []
+      }
+    ],
+    "src/mcp_vacuum/mcp_client/exceptions.py": [
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "message",
+              "type": "str"
+            },
+            {
+              "name": "error_code",
+              "type": "int | None"
+            },
+            {
+              "name": "error_data",
+              "type": "dict | None"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "tool_name",
+              "type": "str"
+            },
+            {
+              "name": "message",
+              "type": "str"
+            },
+            {
+              "name": "error_code",
+              "type": "int | None"
+            },
+            {
+              "name": "error_data",
+              "type": "dict | None"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      }
+    ],
+    "src/mcp_vacuum/mcp_client/http_client.py": [
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "service_record",
+              "type": "MCPServiceRecord"
+            },
+            {
+              "name": "config",
+              "type": "Config"
+            },
+            {
+              "name": "aiohttp_session",
+              "type": "aiohttp.ClientSession | None"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      }
+    ],
+    "src/mcp_vacuum/models/auth.py": [
+      {
+        "name": "is_expired",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": "bool"
+        },
+        "docstring": "Check if token is expired with a 60-second buffer.",
+        "dependencies": []
+      },
+      {
+        "name": "expires_at",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": "float | None"
+        },
+        "docstring": null,
+        "dependencies": []
+      }
+    ],
+    "src/mcp_vacuum/schema_gen/schema_converter_service.py": [
+      {
+        "name": "has_errors",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": "bool"
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "app_config",
+              "type": "Config"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "_sanitize_k8s_name",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "name",
+              "type": "str"
+            },
+            {
+              "name": "max_length",
+              "type": "int"
+            }
+          ],
+          "return_type": "str"
+        },
+        "docstring": "Sanitizes a string to be a Kubernetes-compliant name.",
+        "dependencies": []
+      },
+      {
+        "name": "_to_camel_case",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "snake_str",
+              "type": "str"
+            }
+          ],
+          "return_type": "str"
+        },
+        "docstring": "Converts snake_case or kebab-case to camelCase.",
+        "dependencies": []
+      },
+      {
+        "name": "_categorize_tool",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "mcp_tool",
+              "type": "MCPTool"
+            }
+          ],
+          "return_type": "ToolCategory"
+        },
+        "docstring": "Categorizes the tool based on name, description, schema (simplified).",
+        "dependencies": []
+      },
+      {
+        "name": "_assess_risk_level",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "mcp_tool",
+              "type": "MCPTool"
+            },
+            {
+              "name": "category",
+              "type": "ToolCategory"
+            }
+          ],
+          "return_type": "RiskLevel"
+        },
+        "docstring": "Assesses risk level (simplified).",
+        "dependencies": []
+      },
+      {
+        "name": "_transform_json_schema_to_k8s_crd",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "json_schema",
+              "type": "dict[str, Any]"
+            },
+            {
+              "name": "is_output_schema",
+              "type": "bool"
+            },
+            {
+              "name": "mcp_tool_name",
+              "type": "str | None"
+            }
+          ],
+          "return_type": "KagentCRDSchema"
+        },
+        "docstring": "Converts a JSON Schema (Draft 7) to a Kubernetes CRD OpenAPI v3 compatible schema structure.\nThis is a complex task. This implementation will be a simplified version for P0.\n- Removes unsupported keywords ($schema, $id).\n- Renames fields to camelCase if properties exist.\n- Recursively processes nested schemas (properties, items).",
+        "dependencies": []
+      },
+      {
+        "name": "transform_node",
+        "signature": {
+          "args": [
+            {
+              "name": "node",
+              "type": "dict[str, Any]"
+            }
+          ],
+          "return_type": "dict[str, Any]"
+        },
+        "docstring": null,
+        "dependencies": []
+      }
+    ],
+    "src/mcp_vacuum/server.py": [
+      {
+        "name": "parse_auth_method",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "v",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": "Parse auth method from string if needed.",
+        "dependencies": []
+      },
+      {
+        "name": "validate_endpoint",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "v",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": "Validate endpoint URL format.",
+        "dependencies": []
+      },
+      {
+        "name": "host",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": "str"
+        },
+        "docstring": "Get the host from endpoint.",
+        "dependencies": []
+      },
+      {
+        "name": "port",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": "int"
+        },
+        "docstring": "Get the port from endpoint.",
+        "dependencies": []
+      },
+      {
+        "name": "is_secure",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": "bool"
+        },
+        "docstring": "Check if the server uses HTTPS.",
+        "dependencies": []
+      },
+      {
+        "name": "requires_auth",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": "bool"
+        },
+        "docstring": "Check if server requires authentication.",
+        "dependencies": []
+      },
+      {
+        "name": "is_authenticated",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": "bool"
+        },
+        "docstring": "Check if server is authenticated.",
+        "dependencies": []
+      },
+      {
+        "name": "update_status",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "status",
+              "type": "ServerStatus"
+            }
+          ],
+          "return_type": "None"
+        },
+        "docstring": "Update server status.",
+        "dependencies": []
+      },
+      {
+        "name": "set_auth_credentials",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "credentials",
+              "type": "AuthCredentials"
+            }
+          ],
+          "return_type": "None"
+        },
+        "docstring": "Set authentication credentials.",
+        "dependencies": []
+      },
+      {
+        "name": "set_capabilities",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "capabilities",
+              "type": "ServerCapabilities"
+            }
+          ],
+          "return_type": "None"
+        },
+        "docstring": "Set server capabilities.",
+        "dependencies": []
+      },
+      {
+        "name": "add_metadata",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "key",
+              "type": "str"
+            },
+            {
+              "name": "value",
+              "type": "str"
+            }
+          ],
+          "return_type": "None"
+        },
+        "docstring": "Add metadata to the server.",
+        "dependencies": []
+      },
+      {
+        "name": "get_security_assessment",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": "dict[str, bool]"
+        },
+        "docstring": "Get security assessment of the server.",
+        "dependencies": []
+      },
+      {
+        "name": "to_dict",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": "dict"
+        },
+        "docstring": "Convert server to dictionary representation.",
+        "dependencies": []
+      },
+      {
+        "name": "from_dict",
+        "signature": {
+          "args": [
+            {
+              "name": "cls",
+              "type": null
+            },
+            {
+              "name": "data",
+              "type": "dict"
+            }
+          ],
+          "return_type": "'MCPServer'"
+        },
+        "docstring": "Create server from dictionary representation.",
+        "dependencies": []
+      }
+    ],
+    "src/mcp_vacuum/utils/resilience.py": [
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "message",
+              "type": "str"
+            },
+            {
+              "name": "remaining_time",
+              "type": "float"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "failure_threshold",
+              "type": "int"
+            },
+            {
+              "name": "recovery_timeout_seconds",
+              "type": "float"
+            },
+            {
+              "name": "half_open_max_successes",
+              "type": "int"
+            },
+            {
+              "name": "name",
+              "type": "str | None"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "state",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": "CircuitBreakerState"
+        },
+        "docstring": null,
+        "dependencies": []
+      }
+    ],
+    "tests/adk/test_discovery_agent.py": [
+      {
+        "name": "app_config_adk",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "mock_parent_logger",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "output_queue",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "mock_discovery_service",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "discovery_agent",
+        "signature": {
+          "args": [
+            {
+              "name": "MockDiscoveryServiceCls",
+              "type": null
+            },
+            {
+              "name": "app_config_adk",
+              "type": null
+            },
+            {
+              "name": "mock_parent_logger",
+              "type": null
+            },
+            {
+              "name": "output_queue",
+              "type": null
+            },
+            {
+              "name": "mock_discovery_service",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      }
+    ],
+    "tests/test_config.py": [
+      {
+        "name": "test_config_from_env",
+        "signature": {
+          "args": [
+            {
+              "name": "monkeypatch",
+              "type": null
+            }
+          ],
+          "return_type": "None"
+        },
+        "docstring": "Test loading configuration from environment variables.",
+        "dependencies": []
+      },
+      {
+        "name": "test_config_defaults",
+        "signature": {
+          "args": [],
+          "return_type": "None"
+        },
+        "docstring": "Test default configuration values for new and existing fields.",
+        "dependencies": []
+      },
+      {
+        "name": "test_config_from_file",
+        "signature": {
+          "args": [
+            {
+              "name": "tmp_path",
+              "type": null
+            }
+          ],
+          "return_type": "None"
+        },
+        "docstring": "Test loading configuration from a JSON file.",
+        "dependencies": [
+          "json"
+        ]
+      },
+      {
+        "name": "test_partial_config_from_file",
+        "signature": {
+          "args": [
+            {
+              "name": "tmp_path",
+              "type": null
+            }
+          ],
+          "return_type": "None"
+        },
+        "docstring": "Test loading partial configuration from a file, defaults should apply.",
+        "dependencies": [
+          "json"
+        ]
+      }
+    ],
+    "tests/test_discovery_service.py": [
+      {
+        "name": "app_config_mdns_enabled",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "discovery_service",
+        "signature": {
+          "args": [
+            {
+              "name": "app_config_mdns_enabled",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "MockAsyncServiceInfo",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": "Mocks zeroconf.asyncio.AsyncServiceInfo.",
+        "dependencies": []
+      },
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "type_",
+              "type": "str"
+            },
+            {
+              "name": "name",
+              "type": "str"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "parsed_addresses",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "version",
+              "type": null
+            }
+          ],
+          "return_type": "List[str]"
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "parsed_addresses_by_version",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "version",
+              "type": "int"
+            }
+          ],
+          "return_type": "List[str]"
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "MockAsyncServiceBrowser",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": "Mocks zeroconf.asyncio.AsyncServiceBrowser.",
+        "dependencies": []
+      },
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "aiozc_zeroconf",
+              "type": null
+            },
+            {
+              "name": "service_types",
+              "type": null
+            },
+            {
+              "name": "handlers",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "MockAsyncZeroconf",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": "Mocks zeroconf.asyncio.AsyncZeroconf.",
+        "dependencies": []
+      },
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      }
+    ],
+    "tests/test_environment.py": [
+      {
+        "name": "test_python_version",
+        "signature": {
+          "args": [],
+          "return_type": "None"
+        },
+        "docstring": "Ensure we're running Python 3.12+.",
+        "dependencies": []
+      },
+      {
+        "name": "test_project_structure",
+        "signature": {
+          "args": [],
+          "return_type": "None"
+        },
+        "docstring": "Verify basic project structure.",
+        "dependencies": []
+      },
+      {
+        "name": "test_development_tools",
+        "signature": {
+          "args": [],
+          "return_type": "None"
+        },
+        "docstring": "Verify development tools are installed.",
+        "dependencies": []
+      }
+    ],
+    "tests/test_http_mcp_client.py": [
+      {
+        "name": "app_config",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "service_record",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "mock_aiohttp_session_post",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": "Fixture to provide a mock for aiohttp.ClientSession.post method.",
+        "dependencies": []
+      }
+    ],
+    "tests/test_models.py": [
+      {
+        "name": "test_oauth2token_is_expired",
+        "signature": {
+          "args": [],
+          "return_type": "None"
+        },
+        "docstring": "Test OAuth2Token.is_expired property.",
+        "dependencies": []
+      },
+      {
+        "name": "test_pkce_challenge_validation",
+        "signature": {
+          "args": [],
+          "return_type": "None"
+        },
+        "docstring": "Test PKCEChallenge model validation (though it's mostly for data holding).",
+        "dependencies": []
+      },
+      {
+        "name": "test_mcp_service_record_creation",
+        "signature": {
+          "args": [],
+          "return_type": "None"
+        },
+        "docstring": "Test basic creation and HttpUrl validation for MCPServiceRecord.",
+        "dependencies": []
+      },
+      {
+        "name": "test_mcp_tool_creation",
+        "signature": {
+          "args": [],
+          "return_type": "None"
+        },
+        "docstring": "Test MCPTool creation with required schema fields.",
+        "dependencies": []
+      },
+      {
+        "name": "test_kagent_tool_creation",
+        "signature": {
+          "args": [],
+          "return_type": "None"
+        },
+        "docstring": "Test KagentTool creation with nested models.",
+        "dependencies": []
+      },
+      {
+        "name": "test_kagent_crd_schema_extra_fields",
+        "signature": {
+          "args": [],
+          "return_type": "None"
+        },
+        "docstring": "Test KagentCRDSchema allows extra fields (as JSON schema can be flexible).",
+        "dependencies": []
+      },
+      {
+        "name": "test_enum_usage_in_models",
+        "signature": {
+          "args": [],
+          "return_type": "None"
+        },
+        "docstring": "Test that enums are correctly used and validated in models.",
+        "dependencies": []
+      },
+      {
+        "name": "test_mcp_capability_type",
+        "signature": {
+          "args": [],
+          "return_type": "None"
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "test_model_field_defaults",
+        "signature": {
+          "args": [],
+          "return_type": "None"
+        },
+        "docstring": "Test default values for various model fields.",
+        "dependencies": []
+      },
+      {
+        "name": "test_validation_result",
+        "signature": {
+          "args": [],
+          "return_type": "None"
+        },
+        "docstring": null,
+        "dependencies": []
+      }
+    ],
+    "tests/test_oauth_client.py": [
+      {
+        "name": "app_config",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "oauth_client_config_data",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "oauth_client",
+        "signature": {
+          "args": [
+            {
+              "name": "oauth_client_config_data",
+              "type": null
+            },
+            {
+              "name": "app_config",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      }
+    ],
+    "tests/test_pkce.py": [
+      {
+        "name": "test_generate_pkce_s256",
+        "signature": {
+          "args": [],
+          "return_type": "None"
+        },
+        "docstring": "Test S256 PKCE challenge generation.",
+        "dependencies": []
+      },
+      {
+        "name": "test_generate_pkce_plain",
+        "signature": {
+          "args": [],
+          "return_type": "None"
+        },
+        "docstring": "Test 'plain' PKCE challenge generation.",
+        "dependencies": []
+      },
+      {
+        "name": "test_generate_pkce_unsupported_method",
+        "signature": {
+          "args": [],
+          "return_type": "None"
+        },
+        "docstring": "Test error handling for unsupported challenge methods.",
+        "dependencies": []
+      },
+      {
+        "name": "test_pkce_verifier_default_generation",
+        "signature": {
+          "args": [],
+          "return_type": "None"
+        },
+        "docstring": "Test that the default generate_pkce_challenge_pair function generates a verifier of max allowed length.",
+        "dependencies": []
+      },
+      {
+        "name": "test_pkce_model_accepts_various_verifier_lengths",
+        "signature": {
+          "args": [
+            {
+              "name": "verifier_length",
+              "type": "int"
+            }
+          ],
+          "return_type": "None"
+        },
+        "docstring": "Test that the PKCEChallenge model accepts verifiers of various allowed lengths.",
+        "dependencies": []
+      },
+      {
+        "name": "test_pkce_model_rejects_invalid_verifier_lengths",
+        "signature": {
+          "args": [],
+          "return_type": "None"
+        },
+        "docstring": "Test that the PKCEChallenge model rejects verifiers of invalid lengths.",
+        "dependencies": []
+      },
+      {
+        "name": "test_pkce_minimum_length_verifier_challenge_computation",
+        "signature": {
+          "args": [],
+          "return_type": "None"
+        },
+        "docstring": "Test that a 43-character code_verifier is accepted and challenge is computed correctly by the model.",
+        "dependencies": []
+      }
+    ],
+    "tests/test_schema_converter_service.py": [
+      {
+        "name": "app_config",
+        "signature": {
+          "args": [],
+          "return_type": "Config"
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "converter_service",
+        "signature": {
+          "args": [
+            {
+              "name": "app_config",
+              "type": "Config"
+            }
+          ],
+          "return_type": "SchemaConverterService"
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "sample_mcp_tool",
+        "signature": {
+          "args": [],
+          "return_type": "MCPTool"
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "sample_server_info",
+        "signature": {
+          "args": [],
+          "return_type": "MCPServerInfo"
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "test_sanitize_k8s_name",
+        "signature": {
+          "args": [
+            {
+              "name": "converter_service",
+              "type": "SchemaConverterService"
+            }
+          ],
+          "return_type": "None"
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "test_to_camel_case",
+        "signature": {
+          "args": [
+            {
+              "name": "converter_service",
+              "type": "SchemaConverterService"
+            }
+          ],
+          "return_type": "None"
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "test_categorize_tool",
+        "signature": {
+          "args": [
+            {
+              "name": "converter_service",
+              "type": "SchemaConverterService"
+            },
+            {
+              "name": "sample_mcp_tool",
+              "type": "MCPTool"
+            }
+          ],
+          "return_type": "None"
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "test_assess_risk_level",
+        "signature": {
+          "args": [
+            {
+              "name": "converter_service",
+              "type": "SchemaConverterService"
+            }
+          ],
+          "return_type": "None"
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "test_transform_json_schema_to_k8s_crd_input_params",
+        "signature": {
+          "args": [
+            {
+              "name": "converter_service",
+              "type": "SchemaConverterService"
+            },
+            {
+              "name": "mcp_schema",
+              "type": "dict[str, Any]"
+            },
+            {
+              "name": "expected_k8s_props",
+              "type": "dict[str, Any] | None"
+            },
+            {
+              "name": "sample_mcp_tool",
+              "type": "MCPTool"
+            }
+          ],
+          "return_type": "None"
+        },
+        "docstring": "Test input schema transformation (must result in an object schema for parameters).",
+        "dependencies": []
+      },
+      {
+        "name": "test_transform_json_schema_to_k8s_crd_output_schema",
+        "signature": {
+          "args": [
+            {
+              "name": "converter_service",
+              "type": "SchemaConverterService"
+            },
+            {
+              "name": "sample_mcp_tool",
+              "type": "MCPTool"
+            }
+          ],
+          "return_type": "None"
+        },
+        "docstring": "Test output schema transformation (can be non-object).",
+        "dependencies": []
+      }
+    ],
+    "tests/test_token_manager.py": [
+      {
+        "name": "app_config",
+        "signature": {
+          "args": [],
+          "return_type": "Config"
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "mock_token_storage",
+        "signature": {
+          "args": [],
+          "return_type": "AsyncMock"
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "token_manager",
+        "signature": {
+          "args": [
+            {
+              "name": "app_config",
+              "type": null
+            },
+            {
+              "name": "mock_token_storage",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "sample_server_info",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      }
+    ],
+    "tests/test_token_storage.py": [
+      {
+        "name": "auth_config_keyring",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "mock_keyring_module",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "set_password_mock",
+        "signature": {
+          "args": [
+            {
+              "name": "service",
+              "type": null
+            },
+            {
+              "name": "username",
+              "type": null
+            },
+            {
+              "name": "password",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "get_password_mock",
+        "signature": {
+          "args": [
+            {
+              "name": "service",
+              "type": null
+            },
+            {
+              "name": "username",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "delete_password_mock",
+        "signature": {
+          "args": [
+            {
+              "name": "service",
+              "type": null
+            },
+            {
+              "name": "username",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "test_get_token_storage_factory",
+        "signature": {
+          "args": [
+            {
+              "name": "auth_config_keyring",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": "Test the get_token_storage factory function.",
+        "dependencies": []
+      }
+    ]
+  },
+  "main": {
+    "src/mcp_vacuum/__main__.py": [
+      {
+        "name": "cli",
+        "signature": {
+          "args": [
+            {
+              "name": "ctx",
+              "type": "click.Context"
+            },
+            {
+              "name": "config_file",
+              "type": "Optional[str]"
+            },
+            {
+              "name": "log_level",
+              "type": "Optional[str]"
+            },
+            {
+              "name": "log_format",
+              "type": "Optional[str]"
+            }
+          ],
+          "return_type": "None"
+        },
+        "docstring": "MCP Vacuum - Discovers MCP servers, authenticates, and converts schemas.",
+        "dependencies": [
+          "traceback"
+        ]
+      },
+      {
+        "name": "discover",
+        "signature": {
+          "args": [
+            {
+              "name": "ctx",
+              "type": "click.Context"
+            },
+            {
+              "name": "networks",
+              "type": "List[str]"
+            },
+            {
+              "name": "output_file",
+              "type": "Optional[str]"
+            }
+          ],
+          "return_type": "None"
+        },
+        "docstring": "Discovers MCP servers, authenticates, and generates Kagent schemas.",
+        "dependencies": []
+      },
+      {
+        "name": "version",
+        "signature": {
+          "args": [
+            {
+              "name": "ctx",
+              "type": "click.Context"
+            }
+          ],
+          "return_type": "None"
+        },
+        "docstring": "Show version information.",
+        "dependencies": [
+          null
+        ]
+      },
+      {
+        "name": "config_show",
+        "signature": {
+          "args": [
+            {
+              "name": "ctx",
+              "type": "click.Context"
+            }
+          ],
+          "return_type": "None"
+        },
+        "docstring": "Show current configuration.",
+        "dependencies": [
+          "json"
+        ]
+      }
+    ],
+    "src/mcp_vacuum/adk/auth_agent.py": [
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "server_id",
+              "type": "str"
+            },
+            {
+              "name": "success",
+              "type": "bool"
+            },
+            {
+              "name": "auth_data",
+              "type": "Optional[Dict[str, Any]]"
+            },
+            {
+              "name": "error_message",
+              "type": "Optional[str]"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "__repr__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "app_config",
+              "type": "Config"
+            },
+            {
+              "name": "parent_logger",
+              "type": "structlog.BoundLogger"
+            },
+            {
+              "name": "output_queue",
+              "type": "asyncio.Queue"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      }
+    ],
+    "src/mcp_vacuum/adk/base.py": [
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "agent_name",
+              "type": "str"
+            },
+            {
+              "name": "app_config",
+              "type": "Config"
+            },
+            {
+              "name": "parent_logger",
+              "type": "Optional[structlog.BoundLogger]"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": "Args:\n    agent_name: A unique name for this agent instance.\n    app_config: The global application configuration.\n    parent_logger: Optional logger from a parent agent for hierarchical logging.\n    **kwargs: Additional arguments for the underlying ADK BaseAgent.",
+        "dependencies": []
+      }
+    ],
+    "src/mcp_vacuum/adk/conversion_agent.py": [
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "server_id",
+              "type": "str"
+            },
+            {
+              "name": "success",
+              "type": "bool"
+            },
+            {
+              "name": "kagent_tools_schemas",
+              "type": "Optional[List[KagentTool]]"
+            },
+            {
+              "name": "original_tool_count",
+              "type": "Optional[int]"
+            },
+            {
+              "name": "error_message",
+              "type": "Optional[str]"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "__repr__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "app_config",
+              "type": "Config"
+            },
+            {
+              "name": "parent_logger",
+              "type": "structlog.BoundLogger"
+            },
+            {
+              "name": "output_queue",
+              "type": "asyncio.Queue"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      }
+    ],
+    "src/mcp_vacuum/adk/discovery_agent.py": [
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "server_info",
+              "type": "MCPServiceRecord"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "__repr__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "app_config",
+              "type": "Config"
+            },
+            {
+              "name": "parent_logger",
+              "type": "structlog.BoundLogger"
+            },
+            {
+              "name": "output_queue",
+              "type": "asyncio.Queue"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      }
+    ],
+    "src/mcp_vacuum/adk/mcp_client_agent.py": [
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "app_config",
+              "type": "Config"
+            },
+            {
+              "name": "parent_logger",
+              "type": "structlog.BoundLogger"
+            },
+            {
+              "name": "auth_agent_ref",
+              "type": "AuthenticationAgent"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      }
+    ],
+    "src/mcp_vacuum/adk/orchestration_agent.py": [
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "target_networks",
+              "type": "Optional[List[str]]"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "server_id",
+              "type": "str"
+            },
+            {
+              "name": "server_info",
+              "type": "Dict[str, Any]"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "server_id",
+              "type": "str"
+            },
+            {
+              "name": "mcp_tools_data",
+              "type": "List[Dict[str, Any]]"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "app_config",
+              "type": "Config"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "_setup_global_logging",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": "None"
+        },
+        "docstring": null,
+        "dependencies": [
+          "logging"
+        ]
+      },
+      {
+        "name": "get_summary",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": "Dict[str, int]"
+        },
+        "docstring": null,
+        "dependencies": []
+      }
+    ],
+    "src/mcp_vacuum/auth/dynamic_registration.py": [
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "app_config",
+              "type": "Config"
+            },
+            {
+              "name": "session",
+              "type": "Optional[aiohttp.ClientSession]"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": "Initializes the DynamicClientRegistrar.\n\nArgs:\n    app_config: Global application configuration.\n    session: An optional shared aiohttp.ClientSession.",
+        "dependencies": []
+      }
+    ],
+    "src/mcp_vacuum/auth/oauth_client.py": [
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "client_config",
+              "type": "OAuth2ClientConfig"
+            },
+            {
+              "name": "app_config",
+              "type": "Config"
+            },
+            {
+              "name": "session",
+              "type": "Optional[aiohttp.ClientSession]"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": "Initializes the OAuth2 client.\n\nArgs:\n    client_config: Configuration specific to this OAuth client instance (client_id, endpoints, etc.).\n    app_config: Global application configuration, used for HTTP client settings.\n    session: An optional shared aiohttp.ClientSession. If None, one will be created.",
+        "dependencies": []
+      },
+      {
+        "name": "create_authorization_url",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "state",
+              "type": "str"
+            },
+            {
+              "name": "pkce",
+              "type": "PKCEChallenge"
+            },
+            {
+              "name": "extra_params",
+              "type": "Optional[Dict[str, str]]"
+            }
+          ],
+          "return_type": "Tuple[str, str, str]"
+        },
+        "docstring": "Creates the authorization URL to redirect the user to.\n\nArgs:\n    state: An opaque value used to maintain state between the request and callback.\n    pkce: The PKCEChallenge object containing verifier, challenge, and method.\n    extra_params: Additional query parameters to include in the authorization request.\n\nReturns:\n    A tuple containing:\n    - The full authorization URL.\n    - The state parameter used.\n    - The PKCE code verifier.",
+        "dependencies": []
+      }
+    ],
+    "src/mcp_vacuum/auth/pkce.py": [
+      {
+        "name": "generate_pkce_challenge_pair",
+        "signature": {
+          "args": [
+            {
+              "name": "code_challenge_method",
+              "type": "str"
+            }
+          ],
+          "return_type": "PKCEChallenge"
+        },
+        "docstring": "Generates a PKCE code_verifier and a corresponding code_challenge.\n\nArgs:\n    code_challenge_method: The method used to generate the challenge.\n                           Currently supports \"S256\" or \"plain\".\n\nReturns:\n    A PKCEChallenge object containing the verifier, challenge, and method.\n\nRaises:\n    ValueError: If an unsupported code_challenge_method is provided.",
+        "dependencies": []
+      }
+    ],
+    "src/mcp_vacuum/auth/token_manager.py": [
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "app_config",
+              "type": "Config"
+            },
+            {
+              "name": "token_storage",
+              "type": "Optional[BaseTokenStorage]"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": "Initializes the TokenManager.\n\nArgs:\n    app_config: The global application configuration.\n    token_storage: An instance of a token storage backend. If None, one will be created\n                   based on app_config.auth.",
+        "dependencies": []
+      }
+    ],
+    "src/mcp_vacuum/auth/token_storage.py": [
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "auth_config",
+              "type": "AuthConfig"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "_get_key",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "server_id",
+              "type": "str"
+            },
+            {
+              "name": "suffix",
+              "type": "str"
+            }
+          ],
+          "return_type": "str"
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "auth_config",
+              "type": "AuthConfig"
+            },
+            {
+              "name": "encryption_key",
+              "type": "bytes"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "derive_key_from_password",
+        "signature": {
+          "args": [
+            {
+              "name": "password",
+              "type": "str"
+            },
+            {
+              "name": "salt",
+              "type": "bytes"
+            }
+          ],
+          "return_type": "bytes"
+        },
+        "docstring": "Derives an encryption key from a password using PBKDF2HMAC-SHA256.",
+        "dependencies": []
+      },
+      {
+        "name": "get_token_storage",
+        "signature": {
+          "args": [
+            {
+              "name": "auth_config",
+              "type": "AuthConfig"
+            }
+          ],
+          "return_type": "BaseTokenStorage"
+        },
+        "docstring": "Factory function to get a token storage instance based on configuration.\nRequires ENCRYPTION_KEY_ENV_VAR or similar for EncryptedFileTokenStorage if used.",
+        "dependencies": []
+      }
+    ],
+    "src/mcp_vacuum/config.py": [
+      {
+        "name": "from_file",
+        "signature": {
+          "args": [
+            {
+              "name": "cls",
+              "type": null
+            },
+            {
+              "name": "file_path",
+              "type": "Path"
+            }
+          ],
+          "return_type": "'Config'"
+        },
+        "docstring": "Create configuration strictly from a JSON file.\nNote: This does not layer with environment variables. For layered loading,\npydantic-settings offers other mechanisms if env_file in SettingsConfigDict is not sufficient.",
+        "dependencies": []
+      }
+    ],
+    "src/mcp_vacuum/discovery/discovery_service.py": [
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "app_config",
+              "type": "Config"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "get_cached_server",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "server_id",
+              "type": "str"
+            }
+          ],
+          "return_type": "Optional[MCPServiceRecord]"
+        },
+        "docstring": "Returns a cached MCPServiceRecord if found and not expired.",
+        "dependencies": []
+      },
+      {
+        "name": "get_all_cached_servers",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": "List[MCPServiceRecord]"
+        },
+        "docstring": "Returns all currently cached and valid (non-expired TTL) MCPServiceRecords.",
+        "dependencies": []
+      }
+    ],
+    "src/mcp_vacuum/mcp_client/base_client.py": [
+      {
+        "name": "generate_jsonrpc_request",
+        "signature": {
+          "args": [
+            {
+              "name": "method",
+              "type": "str"
+            },
+            {
+              "name": "params",
+              "type": "Optional[Dict[str, Any]]"
+            },
+            {
+              "name": "request_id",
+              "type": "Optional[Union[str, int]]"
+            }
+          ],
+          "return_type": "Dict[str, Any]"
+        },
+        "docstring": "Generates a JSONRPC 2.0 request dictionary.",
+        "dependencies": []
+      },
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "service_record",
+              "type": "MCPServiceRecord"
+            },
+            {
+              "name": "config",
+              "type": "Config"
+            },
+            {
+              "name": "aiohttp_session",
+              "type": "Optional[aiohttp.ClientSession]"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "get_session",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": "Optional[aiohttp.ClientSession]"
+        },
+        "docstring": "Returns the aiohttp session if used by the client (primarily for HTTP-based transports).",
+        "dependencies": []
+      }
+    ],
+    "src/mcp_vacuum/mcp_client/exceptions.py": [
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "message",
+              "type": "str"
+            },
+            {
+              "name": "error_code",
+              "type": "int"
+            },
+            {
+              "name": "error_data",
+              "type": "dict"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "tool_name",
+              "type": "str"
+            },
+            {
+              "name": "message",
+              "type": "str"
+            },
+            {
+              "name": "error_code",
+              "type": "int"
+            },
+            {
+              "name": "error_data",
+              "type": "dict"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      }
+    ],
+    "src/mcp_vacuum/mcp_client/http_client.py": [
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "service_record",
+              "type": "MCPServiceRecord"
+            },
+            {
+              "name": "config",
+              "type": "Config"
+            },
+            {
+              "name": "aiohttp_session",
+              "type": "Optional[aiohttp.ClientSession]"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      }
+    ],
+    "src/mcp_vacuum/models/auth.py": [
+      {
+        "name": "is_expired",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": "bool"
+        },
+        "docstring": "Check if token is expired with a 60-second buffer.",
+        "dependencies": []
+      },
+      {
+        "name": "expires_at",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": "Optional[float]"
+        },
+        "docstring": null,
+        "dependencies": []
+      }
+    ],
+    "src/mcp_vacuum/schema_gen/schema_converter_service.py": [
+      {
+        "name": "has_errors",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": "bool"
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "app_config",
+              "type": "Config"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "_sanitize_k8s_name",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "name",
+              "type": "str"
+            },
+            {
+              "name": "max_length",
+              "type": "int"
+            }
+          ],
+          "return_type": "str"
+        },
+        "docstring": "Sanitizes a string to be a Kubernetes-compliant name.",
+        "dependencies": []
+      },
+      {
+        "name": "_to_camel_case",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "snake_str",
+              "type": "str"
+            }
+          ],
+          "return_type": "str"
+        },
+        "docstring": "Converts snake_case or kebab-case to camelCase.",
+        "dependencies": []
+      },
+      {
+        "name": "_categorize_tool",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "mcp_tool",
+              "type": "MCPTool"
+            }
+          ],
+          "return_type": "ToolCategory"
+        },
+        "docstring": "Categorizes the tool based on name, description, schema (simplified).",
+        "dependencies": []
+      },
+      {
+        "name": "_assess_risk_level",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "mcp_tool",
+              "type": "MCPTool"
+            },
+            {
+              "name": "category",
+              "type": "ToolCategory"
+            }
+          ],
+          "return_type": "RiskLevel"
+        },
+        "docstring": "Assesses risk level (simplified).",
+        "dependencies": []
+      },
+      {
+        "name": "_transform_json_schema_to_k8s_crd",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "json_schema",
+              "type": "Dict[str, Any]"
+            },
+            {
+              "name": "is_output_schema",
+              "type": "bool"
+            },
+            {
+              "name": "mcp_tool_name",
+              "type": "Optional[str]"
+            }
+          ],
+          "return_type": "KagentCRDSchema"
+        },
+        "docstring": "Converts a JSON Schema (Draft 7) to a Kubernetes CRD OpenAPI v3 compatible schema structure.\nThis is a complex task. This implementation will be a simplified version for P0.\n- Removes unsupported keywords ($schema, $id).\n- Renames fields to camelCase if properties exist.\n- Recursively processes nested schemas (properties, items).",
+        "dependencies": []
+      },
+      {
+        "name": "transform_node",
+        "signature": {
+          "args": [
+            {
+              "name": "node",
+              "type": "Dict[str, Any]"
+            }
+          ],
+          "return_type": "Dict[str, Any]"
+        },
+        "docstring": null,
+        "dependencies": []
+      }
+    ],
+    "src/mcp_vacuum/server.py": [
+      {
+        "name": "parse_auth_method",
+        "signature": {
+          "args": [
+            {
+              "name": "cls",
+              "type": null
+            },
+            {
+              "name": "v",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": "Parse auth method from string if needed.",
+        "dependencies": []
+      },
+      {
+        "name": "validate_endpoint",
+        "signature": {
+          "args": [
+            {
+              "name": "cls",
+              "type": null
+            },
+            {
+              "name": "v",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": "Validate endpoint URL format.",
+        "dependencies": []
+      },
+      {
+        "name": "host",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": "str"
+        },
+        "docstring": "Get the host from endpoint.",
+        "dependencies": []
+      },
+      {
+        "name": "port",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": "int"
+        },
+        "docstring": "Get the port from endpoint.",
+        "dependencies": []
+      },
+      {
+        "name": "is_secure",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": "bool"
+        },
+        "docstring": "Check if the server uses HTTPS.",
+        "dependencies": []
+      },
+      {
+        "name": "requires_auth",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": "bool"
+        },
+        "docstring": "Check if server requires authentication.",
+        "dependencies": []
+      },
+      {
+        "name": "is_authenticated",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": "bool"
+        },
+        "docstring": "Check if server is authenticated.",
+        "dependencies": []
+      },
+      {
+        "name": "update_status",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "status",
+              "type": "ServerStatus"
+            }
+          ],
+          "return_type": "None"
+        },
+        "docstring": "Update server status.",
+        "dependencies": []
+      },
+      {
+        "name": "set_auth_credentials",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "credentials",
+              "type": "AuthCredentials"
+            }
+          ],
+          "return_type": "None"
+        },
+        "docstring": "Set authentication credentials.",
+        "dependencies": []
+      },
+      {
+        "name": "set_capabilities",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "capabilities",
+              "type": "ServerCapabilities"
+            }
+          ],
+          "return_type": "None"
+        },
+        "docstring": "Set server capabilities.",
+        "dependencies": []
+      },
+      {
+        "name": "add_metadata",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "key",
+              "type": "str"
+            },
+            {
+              "name": "value",
+              "type": "str"
+            }
+          ],
+          "return_type": "None"
+        },
+        "docstring": "Add metadata to the server.",
+        "dependencies": []
+      },
+      {
+        "name": "get_security_assessment",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": "Dict[str, bool]"
+        },
+        "docstring": "Get security assessment of the server.",
+        "dependencies": []
+      },
+      {
+        "name": "to_dict",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": "dict"
+        },
+        "docstring": "Convert server to dictionary representation.",
+        "dependencies": []
+      },
+      {
+        "name": "from_dict",
+        "signature": {
+          "args": [
+            {
+              "name": "cls",
+              "type": null
+            },
+            {
+              "name": "data",
+              "type": "dict"
+            }
+          ],
+          "return_type": "'MCPServer'"
+        },
+        "docstring": "Create server from dictionary representation.",
+        "dependencies": []
+      }
+    ],
+    "src/mcp_vacuum/utils/resilience.py": [
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "message",
+              "type": "str"
+            },
+            {
+              "name": "remaining_time",
+              "type": "float"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "failure_threshold",
+              "type": "int"
+            },
+            {
+              "name": "recovery_timeout_seconds",
+              "type": "float"
+            },
+            {
+              "name": "half_open_max_successes",
+              "type": "int"
+            },
+            {
+              "name": "name",
+              "type": "Optional[str]"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "state",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": "CircuitBreakerState"
+        },
+        "docstring": null,
+        "dependencies": []
+      }
+    ],
+    "tests/adk/test_discovery_agent.py": [
+      {
+        "name": "app_config_adk",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "mock_parent_logger",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "output_queue",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "mock_discovery_service",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "discovery_agent",
+        "signature": {
+          "args": [
+            {
+              "name": "MockDiscoveryServiceCls",
+              "type": null
+            },
+            {
+              "name": "app_config_adk",
+              "type": null
+            },
+            {
+              "name": "mock_parent_logger",
+              "type": null
+            },
+            {
+              "name": "output_queue",
+              "type": null
+            },
+            {
+              "name": "mock_discovery_service",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      }
+    ],
+    "tests/test_config.py": [
+      {
+        "name": "test_config_from_env",
+        "signature": {
+          "args": [
+            {
+              "name": "monkeypatch",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": "Test loading configuration from environment variables.",
+        "dependencies": []
+      },
+      {
+        "name": "test_config_defaults",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": "Test default configuration values for new and existing fields.",
+        "dependencies": []
+      },
+      {
+        "name": "test_config_from_file",
+        "signature": {
+          "args": [
+            {
+              "name": "tmp_path",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": "Test loading configuration from a JSON file.",
+        "dependencies": [
+          "json"
+        ]
+      },
+      {
+        "name": "test_partial_config_from_file",
+        "signature": {
+          "args": [
+            {
+              "name": "tmp_path",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": "Test loading partial configuration from a file, defaults should apply.",
+        "dependencies": [
+          "json"
+        ]
+      }
+    ],
+    "tests/test_discovery_service.py": [
+      {
+        "name": "app_config_mdns_enabled",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "discovery_service",
+        "signature": {
+          "args": [
+            {
+              "name": "app_config_mdns_enabled",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "MockAsyncServiceInfo",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": "Mocks zeroconf.asyncio.AsyncServiceInfo.",
+        "dependencies": []
+      },
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "type_",
+              "type": "str"
+            },
+            {
+              "name": "name",
+              "type": "str"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "parsed_addresses",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "version",
+              "type": null
+            }
+          ],
+          "return_type": "List[str]"
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "parsed_addresses_by_version",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "version",
+              "type": "int"
+            }
+          ],
+          "return_type": "List[str]"
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "MockAsyncServiceBrowser",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": "Mocks zeroconf.asyncio.AsyncServiceBrowser.",
+        "dependencies": []
+      },
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "aiozc_zeroconf",
+              "type": null
+            },
+            {
+              "name": "service_types",
+              "type": null
+            },
+            {
+              "name": "handlers",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "MockAsyncZeroconf",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": "Mocks zeroconf.asyncio.AsyncZeroconf.",
+        "dependencies": []
+      },
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      }
+    ],
+    "tests/test_environment.py": [
+      {
+        "name": "test_python_version",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": "Ensure we're running Python 3.12+.",
+        "dependencies": []
+      },
+      {
+        "name": "test_project_structure",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": "Verify basic project structure.",
+        "dependencies": []
+      },
+      {
+        "name": "test_development_tools",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": "Verify development tools are installed.",
+        "dependencies": [
+          "ruff",
+          "mypy",
+          "pytest",
+          "black"
+        ]
+      }
+    ],
+    "tests/test_http_mcp_client.py": [
+      {
+        "name": "app_config",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "service_record",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "mock_aiohttp_session_post",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": "Fixture to provide a mock for aiohttp.ClientSession.post method.",
+        "dependencies": []
+      }
+    ],
+    "tests/test_models.py": [
+      {
+        "name": "test_oauth2token_is_expired",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": "Test OAuth2Token.is_expired property.",
+        "dependencies": []
+      },
+      {
+        "name": "test_pkce_challenge_validation",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": "Test PKCEChallenge model validation (though it's mostly for data holding).",
+        "dependencies": []
+      },
+      {
+        "name": "test_mcp_service_record_creation",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": "Test basic creation and HttpUrl validation for MCPServiceRecord.",
+        "dependencies": []
+      },
+      {
+        "name": "test_mcp_tool_creation",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": "Test MCPTool creation with required schema fields.",
+        "dependencies": []
+      },
+      {
+        "name": "test_kagent_tool_creation",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": "Test KagentTool creation with nested models.",
+        "dependencies": []
+      },
+      {
+        "name": "test_kagent_crd_schema_extra_fields",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": "Test KagentCRDSchema allows extra fields (as JSON schema can be flexible).",
+        "dependencies": []
+      },
+      {
+        "name": "test_enum_usage_in_models",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": "Test that enums are correctly used and validated in models.",
+        "dependencies": []
+      },
+      {
+        "name": "test_mcp_capability_type",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "test_model_field_defaults",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": "Test default values for various model fields.",
+        "dependencies": []
+      },
+      {
+        "name": "test_validation_result",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      }
+    ],
+    "tests/test_oauth_client.py": [
+      {
+        "name": "app_config",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "oauth_client_config_data",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "oauth_client",
+        "signature": {
+          "args": [
+            {
+              "name": "oauth_client_config_data",
+              "type": null
+            },
+            {
+              "name": "app_config",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      }
+    ],
+    "tests/test_pkce.py": [
+      {
+        "name": "test_generate_pkce_s256",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": "Test S256 PKCE challenge generation.",
+        "dependencies": []
+      },
+      {
+        "name": "test_generate_pkce_plain",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": "Test 'plain' PKCE challenge generation.",
+        "dependencies": []
+      },
+      {
+        "name": "test_generate_pkce_unsupported_method",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": "Test error handling for unsupported challenge methods.",
+        "dependencies": []
+      },
+      {
+        "name": "test_pkce_verifier_length_generation",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": "Test that verifiers of different valid lengths can be implicitly generated by the model if not the function.",
+        "dependencies": []
+      }
+    ],
+    "tests/test_schema_converter_service.py": [
+      {
+        "name": "app_config",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "converter_service",
+        "signature": {
+          "args": [
+            {
+              "name": "app_config",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "sample_mcp_tool",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "sample_server_info",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "test_sanitize_k8s_name",
+        "signature": {
+          "args": [
+            {
+              "name": "converter_service",
+              "type": "SchemaConverterService"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "test_to_camel_case",
+        "signature": {
+          "args": [
+            {
+              "name": "converter_service",
+              "type": "SchemaConverterService"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "test_categorize_tool",
+        "signature": {
+          "args": [
+            {
+              "name": "converter_service",
+              "type": "SchemaConverterService"
+            },
+            {
+              "name": "sample_mcp_tool",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "test_assess_risk_level",
+        "signature": {
+          "args": [
+            {
+              "name": "converter_service",
+              "type": "SchemaConverterService"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "test_transform_json_schema_to_k8s_crd_input_params",
+        "signature": {
+          "args": [
+            {
+              "name": "converter_service",
+              "type": "SchemaConverterService"
+            },
+            {
+              "name": "mcp_schema",
+              "type": null
+            },
+            {
+              "name": "expected_k8s_props",
+              "type": null
+            },
+            {
+              "name": "sample_mcp_tool",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": "Test input schema transformation (must result in an object schema for parameters).",
+        "dependencies": []
+      },
+      {
+        "name": "test_transform_json_schema_to_k8s_crd_output_schema",
+        "signature": {
+          "args": [
+            {
+              "name": "converter_service",
+              "type": "SchemaConverterService"
+            },
+            {
+              "name": "sample_mcp_tool",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": "Test output schema transformation (can be non-object).",
+        "dependencies": []
+      }
+    ],
+    "tests/test_token_manager.py": [
+      {
+        "name": "app_config",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "mock_token_storage",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "token_manager",
+        "signature": {
+          "args": [
+            {
+              "name": "app_config",
+              "type": null
+            },
+            {
+              "name": "mock_token_storage",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "sample_server_info",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      }
+    ],
+    "tests/test_token_storage.py": [
+      {
+        "name": "auth_config_keyring",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "mock_keyring_module",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "set_password_mock",
+        "signature": {
+          "args": [
+            {
+              "name": "service",
+              "type": null
+            },
+            {
+              "name": "username",
+              "type": null
+            },
+            {
+              "name": "password",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "get_password_mock",
+        "signature": {
+          "args": [
+            {
+              "name": "service",
+              "type": null
+            },
+            {
+              "name": "username",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "delete_password_mock",
+        "signature": {
+          "args": [
+            {
+              "name": "service",
+              "type": null
+            },
+            {
+              "name": "username",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "test_get_token_storage_factory",
+        "signature": {
+          "args": [
+            {
+              "name": "auth_config_keyring",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": "Test the get_token_storage factory function.",
+        "dependencies": []
+      }
+    ]
+  },
+  "refactor/oauth-event-handlers": {
+    "src/mcp_vacuum/__main__.py": [
+      {
+        "name": "cli",
+        "signature": {
+          "args": [
+            {
+              "name": "ctx",
+              "type": "click.Context"
+            },
+            {
+              "name": "config_file",
+              "type": "Optional[str]"
+            },
+            {
+              "name": "log_level",
+              "type": "Optional[str]"
+            },
+            {
+              "name": "log_format",
+              "type": "Optional[str]"
+            }
+          ],
+          "return_type": "None"
+        },
+        "docstring": "MCP Vacuum - Discovers MCP servers, authenticates, and converts schemas.",
+        "dependencies": [
+          "traceback"
+        ]
+      },
+      {
+        "name": "discover",
+        "signature": {
+          "args": [
+            {
+              "name": "ctx",
+              "type": "click.Context"
+            },
+            {
+              "name": "networks",
+              "type": "List[str]"
+            },
+            {
+              "name": "output_file",
+              "type": "Optional[str]"
+            }
+          ],
+          "return_type": "None"
+        },
+        "docstring": "Discovers MCP servers, authenticates, and generates Kagent schemas.",
+        "dependencies": []
+      },
+      {
+        "name": "version",
+        "signature": {
+          "args": [
+            {
+              "name": "ctx",
+              "type": "click.Context"
+            }
+          ],
+          "return_type": "None"
+        },
+        "docstring": "Show version information.",
+        "dependencies": [
+          null
+        ]
+      },
+      {
+        "name": "config_show",
+        "signature": {
+          "args": [
+            {
+              "name": "ctx",
+              "type": "click.Context"
+            }
+          ],
+          "return_type": "None"
+        },
+        "docstring": "Show current configuration.",
+        "dependencies": [
+          "json"
+        ]
+      }
+    ],
+    "src/mcp_vacuum/adk/auth_agent.py": [
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "server_id",
+              "type": "str"
+            },
+            {
+              "name": "success",
+              "type": "bool"
+            },
+            {
+              "name": "auth_data",
+              "type": "Optional[Dict[str, Any]]"
+            },
+            {
+              "name": "error_message",
+              "type": "Optional[str]"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "__repr__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "app_config",
+              "type": "Config"
+            },
+            {
+              "name": "parent_logger",
+              "type": "structlog.BoundLogger"
+            },
+            {
+              "name": "output_queue",
+              "type": "asyncio.Queue"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      }
+    ],
+    "src/mcp_vacuum/adk/auth_handler.py": [
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "queue",
+              "type": "asyncio.Queue"
+            },
+            {
+              "name": "mcp_client_agent",
+              "type": "Any"
+            },
+            {
+              "name": "conversion_agent",
+              "type": "Any"
+            },
+            {
+              "name": "discovered_servers_info",
+              "type": "Dict[str, Any]"
+            },
+            {
+              "name": "authenticated_server_details",
+              "type": "Dict[str, Any]"
+            },
+            {
+              "name": "logger",
+              "type": "Optional[structlog.BoundLogger]"
+            }
+          ],
+          "return_type": "None"
+        },
+        "docstring": "Initialize the AuthEventProcessor.\n\nArgs:\n    queue: Queue containing authentication events to process\n    mcp_client_agent: Reference to the MCP client agent\n    conversion_agent: Reference to the conversion agent\n    discovered_servers_info: Dict of discovered server information\n    authenticated_server_details: Dict to track authenticated servers\n    logger: Optional logger instance\n    **dependencies: Additional dependencies required for processing",
+        "dependencies": []
+      }
+    ],
+    "src/mcp_vacuum/adk/base.py": [
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "agent_name",
+              "type": "str"
+            },
+            {
+              "name": "app_config",
+              "type": "Config"
+            },
+            {
+              "name": "parent_logger",
+              "type": "Optional[structlog.BoundLogger]"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": "Args:\n    agent_name: A unique name for this agent instance.\n    app_config: The global application configuration.\n    parent_logger: Optional logger from a parent agent for hierarchical logging.\n    **kwargs: Additional arguments for the underlying ADK BaseAgent.",
+        "dependencies": []
+      }
+    ],
+    "src/mcp_vacuum/adk/conversion_agent.py": [
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "server_id",
+              "type": "str"
+            },
+            {
+              "name": "success",
+              "type": "bool"
+            },
+            {
+              "name": "kagent_tools_schemas",
+              "type": "Optional[List[KagentTool]]"
+            },
+            {
+              "name": "original_tool_count",
+              "type": "Optional[int]"
+            },
+            {
+              "name": "error_message",
+              "type": "Optional[str]"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "__repr__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "app_config",
+              "type": "Config"
+            },
+            {
+              "name": "parent_logger",
+              "type": "structlog.BoundLogger"
+            },
+            {
+              "name": "output_queue",
+              "type": "asyncio.Queue"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      }
+    ],
+    "src/mcp_vacuum/adk/conversion_handler.py": [
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "queue",
+              "type": "asyncio.Queue"
+            },
+            {
+              "name": "server_kagent_schemas",
+              "type": "Dict[str, Any]"
+            },
+            {
+              "name": "logger",
+              "type": "Optional[structlog.BoundLogger]"
+            }
+          ],
+          "return_type": "None"
+        },
+        "docstring": "Initialize the ConversionEventProcessor.\n\nArgs:\n    queue: Queue containing schema conversion events to process\n    server_kagent_schemas: Dict to store converted schemas by server ID\n    logger: Optional logger instance\n    **dependencies: Additional dependencies required for processing",
+        "dependencies": []
+      }
+    ],
+    "src/mcp_vacuum/adk/discovery_agent.py": [
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "server_info",
+              "type": "MCPServiceRecord"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "__repr__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "app_config",
+              "type": "Config"
+            },
+            {
+              "name": "parent_logger",
+              "type": "structlog.BoundLogger"
+            },
+            {
+              "name": "output_queue",
+              "type": "asyncio.Queue"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      }
+    ],
+    "src/mcp_vacuum/adk/discovery_handler.py": [
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "queue",
+              "type": "asyncio.Queue"
+            },
+            {
+              "name": "auth_agent",
+              "type": "Any"
+            },
+            {
+              "name": "discovered_servers_info",
+              "type": "Dict[str, Any]"
+            },
+            {
+              "name": "logger",
+              "type": "Optional[structlog.BoundLogger]"
+            }
+          ],
+          "return_type": "None"
+        },
+        "docstring": "Initialize the DiscoveryEventProcessor.\n\nArgs:\n    queue: Queue containing discovery events to process\n    auth_agent: Reference to the authentication agent for delegating auth\n    discovered_servers_info: Dict to track discovered server information\n    logger: Optional logger instance\n    **dependencies: Additional dependencies required for processing",
+        "dependencies": []
+      }
+    ],
+    "src/mcp_vacuum/adk/mcp_client_agent.py": [
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "app_config",
+              "type": "Config"
+            },
+            {
+              "name": "parent_logger",
+              "type": "structlog.BoundLogger"
+            },
+            {
+              "name": "auth_agent_ref",
+              "type": "AuthenticationAgent"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      }
+    ],
+    "src/mcp_vacuum/adk/orchestration_agent.py": [
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "target_networks",
+              "type": "Optional[List[str]]"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "server_id",
+              "type": "str"
+            },
+            {
+              "name": "server_info",
+              "type": "Dict[str, Any]"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "server_id",
+              "type": "str"
+            },
+            {
+              "name": "mcp_tools_data",
+              "type": "List[Dict[str, Any]]"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "app_config",
+              "type": "Config"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "_setup_global_logging",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": "None"
+        },
+        "docstring": null,
+        "dependencies": [
+          "logging"
+        ]
+      },
+      {
+        "name": "get_summary",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": "Dict[str, int]"
+        },
+        "docstring": null,
+        "dependencies": []
+      }
+    ],
+    "src/mcp_vacuum/auth/dynamic_registration.py": [
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "app_config",
+              "type": "Config"
+            },
+            {
+              "name": "session",
+              "type": "Optional[aiohttp.ClientSession]"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": "Initializes the DynamicClientRegistrar.\n\nArgs:\n    app_config: Global application configuration.\n    session: An optional shared aiohttp.ClientSession.",
+        "dependencies": []
+      }
+    ],
+    "src/mcp_vacuum/auth/oauth_client.py": [
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "client_config",
+              "type": "OAuth2ClientConfig"
+            },
+            {
+              "name": "app_config",
+              "type": "Config"
+            },
+            {
+              "name": "session",
+              "type": "Optional[aiohttp.ClientSession]"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": "Initializes the OAuth2 client.\n\nArgs:\n    client_config: Configuration specific to this OAuth client instance (client_id, endpoints, etc.).\n    app_config: Global application configuration, used for HTTP client settings.\n    session: An optional shared aiohttp.ClientSession. If None, one will be created.",
+        "dependencies": []
+      },
+      {
+        "name": "create_authorization_url",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "state",
+              "type": "str"
+            },
+            {
+              "name": "pkce",
+              "type": "PKCEChallenge"
+            },
+            {
+              "name": "extra_params",
+              "type": "Optional[Dict[str, str]]"
+            }
+          ],
+          "return_type": "Tuple[str, str, str]"
+        },
+        "docstring": "Creates the authorization URL to redirect the user to.\n\nArgs:\n    state: An opaque value used to maintain state between the request and callback.\n    pkce: The PKCEChallenge object containing verifier, challenge, and method.\n    extra_params: Additional query parameters to include in the authorization request.\n\nReturns:\n    A tuple containing:\n    - The full authorization URL.\n    - The state parameter used.\n    - The PKCE code verifier.",
+        "dependencies": []
+      },
+      {
+        "name": "_prepare_token_request",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "grant_type",
+              "type": "str"
+            },
+            {
+              "name": "token_request_data",
+              "type": "TokenRequest"
+            }
+          ],
+          "return_type": "Tuple[dict, dict, aiohttp.ClientTimeout]"
+        },
+        "docstring": "Prepares the token request payload, headers and timeout settings.\n\nArgs:\n    grant_type: The OAuth2 grant type (e.g. 'authorization_code' or 'refresh_token').\n    token_request_data: The token request data object.\n\nReturns:\n    A tuple containing (payload, headers, timeout) for the token request.",
+        "dependencies": []
+      },
+      {
+        "name": "_parse_token_response",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "token_data",
+              "type": "dict"
+            },
+            {
+              "name": "existing_refresh_token",
+              "type": "Optional[str]"
+            }
+          ],
+          "return_type": "OAuth2Token"
+        },
+        "docstring": "Parses and validates the token response data.\n\nArgs:\n    token_data: The raw token response data.\n    existing_refresh_token: The current refresh token to preserve if a new one isn't provided.\n\nReturns:\n    An OAuth2Token instance.\n\nRaises:\n    MCPAuthError: If the token data is invalid or malformed.",
+        "dependencies": []
+      }
+    ],
+    "src/mcp_vacuum/auth/pkce.py": [
+      {
+        "name": "generate_pkce_challenge_pair",
+        "signature": {
+          "args": [
+            {
+              "name": "code_challenge_method",
+              "type": "str"
+            }
+          ],
+          "return_type": "PKCEChallenge"
+        },
+        "docstring": "Generates a PKCE code_verifier and a corresponding code_challenge.\n\nArgs:\n    code_challenge_method: The method used to generate the challenge.\n                           Currently supports \"S256\" or \"plain\".\n\nReturns:\n    A PKCEChallenge object containing the verifier, challenge, and method.\n\nRaises:\n    ValueError: If an unsupported code_challenge_method is provided.",
+        "dependencies": []
+      }
+    ],
+    "src/mcp_vacuum/auth/token_manager.py": [
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "app_config",
+              "type": "Config"
+            },
+            {
+              "name": "token_storage",
+              "type": "Optional[BaseTokenStorage]"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": "Initializes the TokenManager.\n\nArgs:\n    app_config: The global application configuration.\n    token_storage: An instance of a token storage backend. If None, one will be created\n                   based on app_config.auth.",
+        "dependencies": []
+      }
+    ],
+    "src/mcp_vacuum/auth/token_storage.py": [
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "auth_config",
+              "type": "AuthConfig"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "_get_key",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "server_id",
+              "type": "str"
+            },
+            {
+              "name": "suffix",
+              "type": "str"
+            }
+          ],
+          "return_type": "str"
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "auth_config",
+              "type": "AuthConfig"
+            },
+            {
+              "name": "encryption_key",
+              "type": "bytes"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "derive_key_from_password",
+        "signature": {
+          "args": [
+            {
+              "name": "password",
+              "type": "str"
+            },
+            {
+              "name": "salt",
+              "type": "bytes"
+            }
+          ],
+          "return_type": "bytes"
+        },
+        "docstring": "Derives an encryption key from a password using PBKDF2HMAC-SHA256.",
+        "dependencies": []
+      },
+      {
+        "name": "get_token_storage",
+        "signature": {
+          "args": [
+            {
+              "name": "auth_config",
+              "type": "AuthConfig"
+            }
+          ],
+          "return_type": "BaseTokenStorage"
+        },
+        "docstring": "Factory function to get a token storage instance based on configuration.\nRequires ENCRYPTION_KEY_ENV_VAR or similar for EncryptedFileTokenStorage if used.",
+        "dependencies": []
+      }
+    ],
+    "src/mcp_vacuum/config.py": [
+      {
+        "name": "from_file",
+        "signature": {
+          "args": [
+            {
+              "name": "cls",
+              "type": null
+            },
+            {
+              "name": "file_path",
+              "type": "Path"
+            }
+          ],
+          "return_type": "'Config'"
+        },
+        "docstring": "Create configuration strictly from a JSON file.\nNote: This does not layer with environment variables. For layered loading,\npydantic-settings offers other mechanisms if env_file in SettingsConfigDict is not sufficient.",
+        "dependencies": []
+      }
+    ],
+    "src/mcp_vacuum/discovery/discovery_service.py": [
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "app_config",
+              "type": "Config"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "get_cached_server",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "server_id",
+              "type": "str"
+            }
+          ],
+          "return_type": "Optional[MCPServiceRecord]"
+        },
+        "docstring": "Returns a cached MCPServiceRecord if found and not expired.",
+        "dependencies": []
+      },
+      {
+        "name": "get_all_cached_servers",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": "List[MCPServiceRecord]"
+        },
+        "docstring": "Returns all currently cached and valid (non-expired TTL) MCPServiceRecords.",
+        "dependencies": []
+      }
+    ],
+    "src/mcp_vacuum/mcp_client/base_client.py": [
+      {
+        "name": "generate_jsonrpc_request",
+        "signature": {
+          "args": [
+            {
+              "name": "method",
+              "type": "str"
+            },
+            {
+              "name": "params",
+              "type": "Optional[Dict[str, Any]]"
+            },
+            {
+              "name": "request_id",
+              "type": "Optional[Union[str, int]]"
+            }
+          ],
+          "return_type": "Dict[str, Any]"
+        },
+        "docstring": "Generates a JSONRPC 2.0 request dictionary.",
+        "dependencies": []
+      },
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "service_record",
+              "type": "MCPServiceRecord"
+            },
+            {
+              "name": "config",
+              "type": "Config"
+            },
+            {
+              "name": "aiohttp_session",
+              "type": "Optional[aiohttp.ClientSession]"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "get_session",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": "Optional[aiohttp.ClientSession]"
+        },
+        "docstring": "Returns the aiohttp session if used by the client (primarily for HTTP-based transports).",
+        "dependencies": []
+      }
+    ],
+    "src/mcp_vacuum/mcp_client/exceptions.py": [
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "message",
+              "type": "str"
+            },
+            {
+              "name": "error_code",
+              "type": "int"
+            },
+            {
+              "name": "error_data",
+              "type": "dict"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "tool_name",
+              "type": "str"
+            },
+            {
+              "name": "message",
+              "type": "str"
+            },
+            {
+              "name": "error_code",
+              "type": "int"
+            },
+            {
+              "name": "error_data",
+              "type": "dict"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      }
+    ],
+    "src/mcp_vacuum/mcp_client/http_client.py": [
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "service_record",
+              "type": "MCPServiceRecord"
+            },
+            {
+              "name": "config",
+              "type": "Config"
+            },
+            {
+              "name": "aiohttp_session",
+              "type": "Optional[aiohttp.ClientSession]"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      }
+    ],
+    "src/mcp_vacuum/models/auth.py": [
+      {
+        "name": "is_expired",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": "bool"
+        },
+        "docstring": "Check if token is expired with a 60-second buffer.",
+        "dependencies": []
+      },
+      {
+        "name": "expires_at",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": "Optional[float]"
+        },
+        "docstring": null,
+        "dependencies": []
+      }
+    ],
+    "src/mcp_vacuum/schema_gen/schema_converter_service.py": [
+      {
+        "name": "has_errors",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": "bool"
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "app_config",
+              "type": "Config"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "_sanitize_k8s_name",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "name",
+              "type": "str"
+            },
+            {
+              "name": "max_length",
+              "type": "int"
+            }
+          ],
+          "return_type": "str"
+        },
+        "docstring": "Sanitizes a string to be a Kubernetes-compliant name.",
+        "dependencies": []
+      },
+      {
+        "name": "_to_camel_case",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "snake_str",
+              "type": "str"
+            }
+          ],
+          "return_type": "str"
+        },
+        "docstring": "Converts snake_case or kebab-case to camelCase.",
+        "dependencies": []
+      },
+      {
+        "name": "_categorize_tool",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "mcp_tool",
+              "type": "MCPTool"
+            }
+          ],
+          "return_type": "ToolCategory"
+        },
+        "docstring": "Categorizes the tool based on name, description, schema (simplified).",
+        "dependencies": []
+      },
+      {
+        "name": "_assess_risk_level",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "mcp_tool",
+              "type": "MCPTool"
+            },
+            {
+              "name": "category",
+              "type": "ToolCategory"
+            }
+          ],
+          "return_type": "RiskLevel"
+        },
+        "docstring": "Assesses risk level (simplified).",
+        "dependencies": []
+      },
+      {
+        "name": "_transform_json_schema_to_k8s_crd",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "json_schema",
+              "type": "Dict[str, Any]"
+            },
+            {
+              "name": "is_output_schema",
+              "type": "bool"
+            },
+            {
+              "name": "mcp_tool_name",
+              "type": "Optional[str]"
+            }
+          ],
+          "return_type": "KagentCRDSchema"
+        },
+        "docstring": "Converts a JSON Schema (Draft 7) to a Kubernetes CRD OpenAPI v3 compatible schema structure.\nThis is a complex task. This implementation will be a simplified version for P0.\n- Removes unsupported keywords ($schema, $id).\n- Renames fields to camelCase if properties exist.\n- Recursively processes nested schemas (properties, items).",
+        "dependencies": []
+      },
+      {
+        "name": "transform_node",
+        "signature": {
+          "args": [
+            {
+              "name": "node",
+              "type": "Dict[str, Any]"
+            }
+          ],
+          "return_type": "Dict[str, Any]"
+        },
+        "docstring": null,
+        "dependencies": []
+      }
+    ],
+    "src/mcp_vacuum/server.py": [
+      {
+        "name": "parse_auth_method",
+        "signature": {
+          "args": [
+            {
+              "name": "cls",
+              "type": null
+            },
+            {
+              "name": "v",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": "Parse auth method from string if needed.",
+        "dependencies": []
+      },
+      {
+        "name": "validate_endpoint",
+        "signature": {
+          "args": [
+            {
+              "name": "cls",
+              "type": null
+            },
+            {
+              "name": "v",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": "Validate endpoint URL format.",
+        "dependencies": []
+      },
+      {
+        "name": "host",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": "str"
+        },
+        "docstring": "Get the host from endpoint.",
+        "dependencies": []
+      },
+      {
+        "name": "port",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": "int"
+        },
+        "docstring": "Get the port from endpoint.",
+        "dependencies": []
+      },
+      {
+        "name": "is_secure",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": "bool"
+        },
+        "docstring": "Check if the server uses HTTPS.",
+        "dependencies": []
+      },
+      {
+        "name": "requires_auth",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": "bool"
+        },
+        "docstring": "Check if server requires authentication.",
+        "dependencies": []
+      },
+      {
+        "name": "is_authenticated",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": "bool"
+        },
+        "docstring": "Check if server is authenticated.",
+        "dependencies": []
+      },
+      {
+        "name": "update_status",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "status",
+              "type": "ServerStatus"
+            }
+          ],
+          "return_type": "None"
+        },
+        "docstring": "Update server status.",
+        "dependencies": []
+      },
+      {
+        "name": "set_auth_credentials",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "credentials",
+              "type": "AuthCredentials"
+            }
+          ],
+          "return_type": "None"
+        },
+        "docstring": "Set authentication credentials.",
+        "dependencies": []
+      },
+      {
+        "name": "set_capabilities",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "capabilities",
+              "type": "ServerCapabilities"
+            }
+          ],
+          "return_type": "None"
+        },
+        "docstring": "Set server capabilities.",
+        "dependencies": []
+      },
+      {
+        "name": "add_metadata",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "key",
+              "type": "str"
+            },
+            {
+              "name": "value",
+              "type": "str"
+            }
+          ],
+          "return_type": "None"
+        },
+        "docstring": "Add metadata to the server.",
+        "dependencies": []
+      },
+      {
+        "name": "get_security_assessment",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": "Dict[str, bool]"
+        },
+        "docstring": "Get security assessment of the server.",
+        "dependencies": []
+      },
+      {
+        "name": "to_dict",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": "dict"
+        },
+        "docstring": "Convert server to dictionary representation.",
+        "dependencies": []
+      },
+      {
+        "name": "from_dict",
+        "signature": {
+          "args": [
+            {
+              "name": "cls",
+              "type": null
+            },
+            {
+              "name": "data",
+              "type": "dict"
+            }
+          ],
+          "return_type": "'MCPServer'"
+        },
+        "docstring": "Create server from dictionary representation.",
+        "dependencies": []
+      }
+    ],
+    "src/mcp_vacuum/utils/resilience.py": [
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "message",
+              "type": "str"
+            },
+            {
+              "name": "remaining_time",
+              "type": "float"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "failure_threshold",
+              "type": "int"
+            },
+            {
+              "name": "recovery_timeout_seconds",
+              "type": "float"
+            },
+            {
+              "name": "half_open_max_successes",
+              "type": "int"
+            },
+            {
+              "name": "name",
+              "type": "Optional[str]"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "state",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": "CircuitBreakerState"
+        },
+        "docstring": null,
+        "dependencies": []
+      }
+    ],
+    "task7_validation.py": [
+      {
+        "name": "validate_task_requirements",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": "Validate all Task 7 requirements have been met.",
+        "dependencies": [
+          "mcp_vacuum.server"
+        ]
+      }
+    ],
+    "tests/adk/test_conversion_agent.py": [
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "settings",
+              "type": "Any"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "logger",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "output_queue",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "test_init_with_fail_fast_true",
+        "signature": {
+          "args": [
+            {
+              "name": "logger",
+              "type": null
+            },
+            {
+              "name": "output_queue",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": "Test ConversionAgent initialization with fail_fast_conversion=True.",
+        "dependencies": []
+      },
+      {
+        "name": "test_init_with_fail_fast_false",
+        "signature": {
+          "args": [
+            {
+              "name": "logger",
+              "type": null
+            },
+            {
+              "name": "output_queue",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": "Test ConversionAgent initialization with fail_fast_conversion=False.",
+        "dependencies": []
+      },
+      {
+        "name": "test_init_with_fail_fast_missing",
+        "signature": {
+          "args": [
+            {
+              "name": "logger",
+              "type": null
+            },
+            {
+              "name": "output_queue",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": "Test ConversionAgent initialization with missing fail_fast_conversion.",
+        "dependencies": []
+      },
+      {
+        "name": "test_init_with_fail_fast_invalid_type",
+        "signature": {
+          "args": [
+            {
+              "name": "logger",
+              "type": null
+            },
+            {
+              "name": "output_queue",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": "Test ConversionAgent initialization with non-boolean fail_fast_conversion.",
+        "dependencies": []
+      },
+      {
+        "name": "test_init_with_agent_settings_none",
+        "signature": {
+          "args": [
+            {
+              "name": "logger",
+              "type": null
+            },
+            {
+              "name": "output_queue",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": "Test ConversionAgent initialization with None agent_settings.",
+        "dependencies": []
+      }
+    ],
+    "tests/adk/test_discovery_agent.py": [
+      {
+        "name": "app_config_adk",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "mock_parent_logger",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "output_queue",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "mock_discovery_service",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "discovery_agent",
+        "signature": {
+          "args": [
+            {
+              "name": "MockDiscoveryServiceCls",
+              "type": null
+            },
+            {
+              "name": "app_config_adk",
+              "type": null
+            },
+            {
+              "name": "mock_parent_logger",
+              "type": null
+            },
+            {
+              "name": "output_queue",
+              "type": null
+            },
+            {
+              "name": "mock_discovery_service",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      }
+    ],
+    "tests/test_config.py": [
+      {
+        "name": "test_config_from_env",
+        "signature": {
+          "args": [
+            {
+              "name": "monkeypatch",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": "Test loading configuration from environment variables.",
+        "dependencies": []
+      },
+      {
+        "name": "test_config_defaults",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": "Test default configuration values for new and existing fields.",
+        "dependencies": []
+      },
+      {
+        "name": "test_config_from_file",
+        "signature": {
+          "args": [
+            {
+              "name": "tmp_path",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": "Test loading configuration from a JSON file.",
+        "dependencies": [
+          "json"
+        ]
+      },
+      {
+        "name": "test_partial_config_from_file",
+        "signature": {
+          "args": [
+            {
+              "name": "tmp_path",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": "Test loading partial configuration from a file, defaults should apply.",
+        "dependencies": [
+          "json"
+        ]
+      }
+    ],
+    "tests/test_discovery_service.py": [
+      {
+        "name": "app_config_mdns_enabled",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "discovery_service",
+        "signature": {
+          "args": [
+            {
+              "name": "app_config_mdns_enabled",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "MockAsyncServiceInfo",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": "Mocks zeroconf.asyncio.AsyncServiceInfo.",
+        "dependencies": []
+      },
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "type_",
+              "type": "str"
+            },
+            {
+              "name": "name",
+              "type": "str"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "parsed_addresses",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "version",
+              "type": null
+            }
+          ],
+          "return_type": "List[str]"
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "parsed_addresses_by_version",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "version",
+              "type": "int"
+            }
+          ],
+          "return_type": "List[str]"
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "MockAsyncServiceBrowser",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": "Mocks zeroconf.asyncio.AsyncServiceBrowser.",
+        "dependencies": []
+      },
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            },
+            {
+              "name": "aiozc_zeroconf",
+              "type": null
+            },
+            {
+              "name": "service_types",
+              "type": null
+            },
+            {
+              "name": "handlers",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "MockAsyncZeroconf",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": "Mocks zeroconf.asyncio.AsyncZeroconf.",
+        "dependencies": []
+      },
+      {
+        "name": "__init__",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      }
+    ],
+    "tests/test_discovery_timeout.py": [
+      {
+        "name": "config",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": "Create a test configuration.",
+        "dependencies": []
+      }
+    ],
+    "tests/test_environment.py": [
+      {
+        "name": "test_python_version",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": "Ensure we're running Python 3.12+.",
+        "dependencies": []
+      },
+      {
+        "name": "test_project_structure",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": "Verify basic project structure.",
+        "dependencies": []
+      },
+      {
+        "name": "test_development_tools",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": "Verify development tools are installed.",
+        "dependencies": [
+          "ruff",
+          "mypy",
+          "pytest",
+          "black"
+        ]
+      }
+    ],
+    "tests/test_http_client_timeout.py": [
+      {
+        "name": "config",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": "Create a test configuration.",
+        "dependencies": []
+      },
+      {
+        "name": "service_record",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": "Create a test service record.",
+        "dependencies": []
+      }
+    ],
+    "tests/test_http_mcp_client.py": [
+      {
+        "name": "app_config",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "service_record",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "mock_aiohttp_session_post",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": "Fixture to provide a mock for aiohttp.ClientSession.post method.",
+        "dependencies": []
+      }
+    ],
+    "tests/test_models.py": [
+      {
+        "name": "test_oauth2token_is_expired",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": "Test OAuth2Token.is_expired property.",
+        "dependencies": []
+      },
+      {
+        "name": "test_pkce_challenge_validation",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": "Test PKCEChallenge model validation (though it's mostly for data holding).",
+        "dependencies": []
+      },
+      {
+        "name": "test_mcp_service_record_creation",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": "Test basic creation and HttpUrl validation for MCPServiceRecord.",
+        "dependencies": []
+      },
+      {
+        "name": "test_mcp_tool_creation",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": "Test MCPTool creation with required schema fields.",
+        "dependencies": []
+      },
+      {
+        "name": "test_kagent_tool_creation",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": "Test KagentTool creation with nested models.",
+        "dependencies": []
+      },
+      {
+        "name": "test_kagent_crd_schema_extra_fields",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": "Test KagentCRDSchema allows extra fields (as JSON schema can be flexible).",
+        "dependencies": []
+      },
+      {
+        "name": "test_enum_usage_in_models",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": "Test that enums are correctly used and validated in models.",
+        "dependencies": []
+      },
+      {
+        "name": "test_mcp_capability_type",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "test_model_field_defaults",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": "Test default values for various model fields.",
+        "dependencies": []
+      },
+      {
+        "name": "test_validation_result",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      }
+    ],
+    "tests/test_oauth_client.py": [
+      {
+        "name": "app_config",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "oauth_client_config_data",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "oauth_client",
+        "signature": {
+          "args": [
+            {
+              "name": "oauth_client_config_data",
+              "type": null
+            },
+            {
+              "name": "app_config",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "test_parse_token_response_success",
+        "signature": {
+          "args": [
+            {
+              "name": "oauth_client",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": "Test _parse_token_response helper method for successful case.",
+        "dependencies": []
+      },
+      {
+        "name": "test_parse_token_response_invalid_data",
+        "signature": {
+          "args": [
+            {
+              "name": "oauth_client",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": "Test _parse_token_response helper method with invalid data.",
+        "dependencies": []
+      }
+    ],
+    "tests/test_pkce.py": [
+      {
+        "name": "test_generate_pkce_s256",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": "Test S256 PKCE challenge generation.",
+        "dependencies": []
+      },
+      {
+        "name": "test_generate_pkce_plain",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": "Test 'plain' PKCE challenge generation.",
+        "dependencies": []
+      },
+      {
+        "name": "test_generate_pkce_unsupported_method",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": "Test error handling for unsupported challenge methods.",
+        "dependencies": []
+      },
+      {
+        "name": "test_pkce_verifier_length_generation",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": "Test that verifiers of different valid lengths can be implicitly generated by the model if not the function.",
+        "dependencies": []
+      }
+    ],
+    "tests/test_pkce_challenge.py": [
+      {
+        "name": "test_valid_code_verifier_characters",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": "Test that valid code verifier characters are accepted.",
+        "dependencies": []
+      },
+      {
+        "name": "test_invalid_code_verifier_with_spaces",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": "Test that code verifier with spaces raises ValidationError.",
+        "dependencies": []
+      },
+      {
+        "name": "test_invalid_code_verifier_with_unicode_non_ascii",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": "Test that code verifier with Unicode non-ASCII characters raises ValidationError.",
+        "dependencies": []
+      },
+      {
+        "name": "test_invalid_code_verifier_with_forbidden_symbols",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": "Test that code verifier with forbidden symbols raises ValidationError.",
+        "dependencies": []
+      },
+      {
+        "name": "test_invalid_code_verifier_mixed_invalid_characters",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": "Test code verifier with mixed invalid characters.",
+        "dependencies": []
+      },
+      {
+        "name": "test_valid_code_challenge_characters",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": "Test that code challenge validation doesn't produce false positives.",
+        "dependencies": []
+      },
+      {
+        "name": "test_length_validation_still_works",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": "Test that length validation still works alongside character validation.",
+        "dependencies": []
+      },
+      {
+        "name": "test_edge_cases",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": "Test edge cases for character validation.",
+        "dependencies": []
+      }
+    ],
+    "tests/test_schema_converter_service.py": [
+      {
+        "name": "app_config",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "converter_service",
+        "signature": {
+          "args": [
+            {
+              "name": "app_config",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "sample_mcp_tool",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "sample_server_info",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "test_sanitize_k8s_name",
+        "signature": {
+          "args": [
+            {
+              "name": "converter_service",
+              "type": "SchemaConverterService"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "test_to_camel_case",
+        "signature": {
+          "args": [
+            {
+              "name": "converter_service",
+              "type": "SchemaConverterService"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "test_categorize_tool",
+        "signature": {
+          "args": [
+            {
+              "name": "converter_service",
+              "type": "SchemaConverterService"
+            },
+            {
+              "name": "sample_mcp_tool",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "test_assess_risk_level",
+        "signature": {
+          "args": [
+            {
+              "name": "converter_service",
+              "type": "SchemaConverterService"
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "test_transform_json_schema_to_k8s_crd_input_params",
+        "signature": {
+          "args": [
+            {
+              "name": "converter_service",
+              "type": "SchemaConverterService"
+            },
+            {
+              "name": "mcp_schema",
+              "type": null
+            },
+            {
+              "name": "expected_k8s_props",
+              "type": null
+            },
+            {
+              "name": "sample_mcp_tool",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": "Test input schema transformation (must result in an object schema for parameters).",
+        "dependencies": []
+      },
+      {
+        "name": "test_transform_json_schema_to_k8s_crd_output_schema",
+        "signature": {
+          "args": [
+            {
+              "name": "converter_service",
+              "type": "SchemaConverterService"
+            },
+            {
+              "name": "sample_mcp_tool",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": "Test output schema transformation (can be non-object).",
+        "dependencies": []
+      }
+    ],
+    "tests/test_server.py": [
+      {
+        "name": "test_parse_auth_method_from_string",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": "Test that auth method validator correctly parses string values.",
+        "dependencies": []
+      },
+      {
+        "name": "test_parse_auth_method_invalid_string",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": "Test that invalid auth method strings raise ValidationError.",
+        "dependencies": []
+      },
+      {
+        "name": "test_auth_credentials_creation_with_different_methods",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": "Test creating AuthCredentials with different auth methods.",
+        "dependencies": []
+      },
+      {
+        "name": "test_validate_endpoint_valid_urls",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": "Test endpoint validator accepts valid URLs.",
+        "dependencies": []
+      },
+      {
+        "name": "test_validate_endpoint_invalid_urls",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": "Test endpoint validator rejects invalid URLs.",
+        "dependencies": []
+      },
+      {
+        "name": "test_server_properties",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": "Test server property methods work correctly.",
+        "dependencies": []
+      },
+      {
+        "name": "test_server_authentication_properties",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": "Test authentication-related properties.",
+        "dependencies": []
+      },
+      {
+        "name": "test_server_status_update",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": "Test server status update functionality.",
+        "dependencies": []
+      },
+      {
+        "name": "test_server_security_assessment",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": "Test security assessment functionality.",
+        "dependencies": []
+      },
+      {
+        "name": "test_server_capabilities_and_metadata",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": "Test server capabilities and metadata functionality.",
+        "dependencies": []
+      },
+      {
+        "name": "test_server_dict_conversion",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": "Test server dictionary conversion methods.",
+        "dependencies": []
+      },
+      {
+        "name": "test_default_capabilities",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": "Test default values for ServerCapabilities.",
+        "dependencies": []
+      },
+      {
+        "name": "test_custom_capabilities",
+        "signature": {
+          "args": [
+            {
+              "name": "self",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": "Test creating ServerCapabilities with custom values.",
+        "dependencies": []
+      }
+    ],
+    "tests/test_token_manager.py": [
+      {
+        "name": "app_config",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "mock_token_storage",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "token_manager",
+        "signature": {
+          "args": [
+            {
+              "name": "app_config",
+              "type": null
+            },
+            {
+              "name": "mock_token_storage",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "sample_server_info",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      }
+    ],
+    "tests/test_token_storage.py": [
+      {
+        "name": "auth_config_keyring",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "mock_keyring_module",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "set_password_mock",
+        "signature": {
+          "args": [
+            {
+              "name": "service",
+              "type": null
+            },
+            {
+              "name": "username",
+              "type": null
+            },
+            {
+              "name": "password",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "get_password_mock",
+        "signature": {
+          "args": [
+            {
+              "name": "service",
+              "type": null
+            },
+            {
+              "name": "username",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "delete_password_mock",
+        "signature": {
+          "args": [
+            {
+              "name": "service",
+              "type": null
+            },
+            {
+              "name": "username",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": null,
+        "dependencies": []
+      },
+      {
+        "name": "test_get_token_storage_factory",
+        "signature": {
+          "args": [
+            {
+              "name": "auth_config_keyring",
+              "type": null
+            }
+          ],
+          "return_type": null
+        },
+        "docstring": "Test the get_token_storage factory function.",
+        "dependencies": []
+      }
+    ],
+    "validator_tests.py": [
+      {
+        "name": "test_auth_credentials_validator",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": "Test AuthCredentials field validator.",
+        "dependencies": []
+      },
+      {
+        "name": "test_mcp_server_validator",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": "Test MCPServer field validator.",
+        "dependencies": []
+      },
+      {
+        "name": "test_field_validator_class_method_signatures",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": "Test that validators use correct @classmethod and cls parameter.",
+        "dependencies": []
+      },
+      {
+        "name": "test_model_functionality",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": "Test overall model functionality with validators.",
+        "dependencies": []
+      },
+      {
+        "name": "main",
+        "signature": {
+          "args": [],
+          "return_type": null
+        },
+        "docstring": "Run all validator tests.",
+        "dependencies": []
+      }
+    ]
+  }
+}

--- a/.local/task-tracker.md
+++ b/.local/task-tracker.md
@@ -1,0 +1,13 @@
+# Task Tracker
+
+## Active Tasks
+- [ ] Initialize local tracking system
+
+## Completed Tasks
+
+## Blocked Tasks
+
+## Notes
+- Created: [Current Date]
+- This file tracks development tasks and their status
+- Tasks should be moved between sections as their status changes

--- a/.metadata/branches/code-review-fixes.md
+++ b/.metadata/branches/code-review-fixes.md
@@ -1,0 +1,22 @@
+# code-review-fixes Branch
+
+## Purpose
+This branch is dedicated to implementing fixes and improvements identified during code review processes. It serves as a consolidated branch for addressing reviewer feedback and maintaining code quality standards.
+
+## Status
+- Current Status: Active
+- Last Sync: $(date)
+- Base Branch: origin/main
+- Sync Status: Up to date with main
+
+## Content Summary
+Branch contains code review-related fixes and improvements, focused on:
+- Code quality enhancements
+- Reviewer feedback implementation
+- Best practice adherence
+
+## Tracking
+- [ ] Code review fixes implemented
+- [ ] Tests updated/added as needed
+- [ ] Documentation updated
+- [ ] Ready for re-review

--- a/README.md
+++ b/README.md
@@ -99,11 +99,9 @@ See `src/mcp_vacuum/config.py` for the full configuration schema. The CLI comman
 
 2.  **Set up the environment using `uv` (recommended):**
     ```bash
-    # Create a virtual environment (e.g., in .venv)
-    uv venv
-    source .venv/bin/activate # Or .venv\Scripts\activate on Windows
-
-    # Install dependencies including development tools
+    # Create a virtual environment and install dependencies
+    uv pip install --system --upgrade pip
+    uv venv .venv --python 3.12
     uv pip install -e ".[dev]"
     ```
     Alternatively, if you prefer `pip` directly (after creating and activating a venv):

--- a/docs/MCP_Vacuum_Project_Specification.md
+++ b/docs/MCP_Vacuum_Project_Specification.md
@@ -1,0 +1,115 @@
+# MCP Vacuum Project Specification
+
+## Project Overview
+
+MCP Vacuum is a Python 3.12-based AI agent designed to automate the discovery of MCP (Model Context Protocol) servers on a local network, authenticate using OAuth 2.1 with PKCE, retrieve tool schemas, and convert them into Kagent-compliant CRD formats for integration into Kagent workflows. Built with Google Python Agent Development Kit (ADK) principles, it features a hierarchical agent architecture for modularity and scalability.
+
+### Project Goals
+
+- **Primary Objectives**:
+  - Automatically discover MCP servers using multiple protocols (mDNS, with SSDP planned).
+  - Authenticate securely with discovered servers using OAuth 2.1 + PKCE and dynamic client registration (RFC 7591).
+  - Retrieve MCP tool schemas and convert them into Kagent CRD format (Agent, ToolServer, ModelConfig).
+  - Deliver a production-ready agent deployable on Google Cloud with Vertex AI integration.
+  - Provide comprehensive documentation, testing, and DevOps integration.
+
+## Technical Requirements
+
+### Discovery
+- **Protocols**: 
+  - Implement mDNS for initial service discovery using `python-zeroconf`.
+  - Plan SSDP integration for broader compatibility (e.g., Windows environments).
+- **Features**:
+  - Cache discovery results with a configurable TTL (default: 600 seconds).
+  - Support concurrent scanning with resource limits (e.g., max 50 workers).
+  - Filter discovered servers by allowed networks (e.g., "192.168.1.0/24").
+- **Output**: List of MCP servers with connection details (e.g., `MCPServiceRecord`).
+
+### Authentication
+- **Method**: OAuth 2.1 with PKCE (RFC 7636).
+- **Features**:
+  - Dynamic client registration per RFC 7591.
+  - Secure token storage using system keyring (default) or encrypted file storage.
+  - Automatic token refresh with short-lived access tokens (15-60 minutes).
+- **Security**:
+  - Exact redirect URI validation.
+  - State parameter for CSRF protection.
+  - Memory-only storage for access tokens.
+
+### MCP Interaction
+- **Protocol**: JSONRPC 2.0 over HTTP.
+- **Operations**:
+  - List available tools via `listTools` method.
+  - Retrieve tool schemas using `getToolSchema` method.
+- **Resilience**:
+  - Implement retry mechanisms with exponential backoff.
+  - Use circuit breakers (e.g., failure threshold: 3, recovery timeout: 20 seconds).
+
+### Schema Conversion
+- **Input**: MCP tool schemas in JSON Schema Draft 7.
+- **Output**: Kagent CRDs in OpenAPI v3 (YAML format).
+- **Conversion Mapping**:
+  - **MCP Server → Kagent ToolServer**:
+    - `server.name` → `metadata.name`: Lowercase, Kubernetes-compliant (e.g., `mcp-server-1`).
+    - `server.description` → `spec.description`: Direct mapping.
+    - Server URL → `spec.config`: Map based on transport (e.g., `sse.url`, `websocket.url`, `stdio`).
+    - Tools: Discovered dynamically at runtime, not statically defined.
+  - **MCP Tool → Kagent Agent Tool Reference**:
+    - `tool.name` → `tools[].mcpServer.toolNames[]`: Array of sanitized tool names.
+    - Tool Server Reference: Link to generated `ToolServer` CRD name.
+    - `type`: Set to `"McpServer"`.
+- **Additional Features**:
+  - **Metadata Enrichment**: Add labels (e.g., `mcp.source: "converted"`) and annotations (e.g., `mcp.conversion.timestamp`).
+  - **Validation**: Ensure CRDs are valid Kubernetes resources using a multi-stage validation pipeline.
+  - **Tool Categorization**: Categorize tools (e.g., `network-access`, `data-processing`) using `ToolAnalyzer`.
+  - **Risk Assessment**: Assign risk levels (e.g., `low`, `medium`, `high`, `critical`) based on schema analysis.
+
+### Output
+- **Format**: Generate Kagent CRD YAML files for `ToolServer` and `Agent` resources.
+- **Options**: Output to file (e.g., `mcp_kagent_schemas.yaml`) or stdout.
+
+### Architecture
+- **Hierarchical Agent System**:
+  - `OrchestrationAgent`: Coordinates workflow and manages child agents.
+  - `DiscoveryAgent`: Handles network scanning and server detection.
+  - `AuthenticationAgent`: Manages OAuth flows and token lifecycle.
+  - `MCPClientAgent`: Communicates with MCP servers via JSONRPC.
+  - `ConversionAgent`: Performs schema transformation and validation.
+- **Event-Driven**: Use `asyncio.Queue` for inter-agent communication.
+- **Modularity**: Ensure components are reusable and independently testable.
+
+### DevOps Integration
+- **Package Management**: Use `uv` for dependency management.
+- **CI/CD**: Implement pipelines with GitHub Actions for testing, linting, and deployment.
+- **Containerization**: Provide a `Dockerfile.prod` for production deployment.
+- **Cloud Deployment**: Integrate with Google Cloud Vertex AI, including auto-scaling and monitoring.
+
+## Success Criteria
+
+### Functional
+- Discover and authenticate with MCP servers on the local network.
+- Convert MCP tool schemas to Kagent CRD format with 100% semantic preservation.
+- Generate valid Kubernetes CRDs deployable to a cluster.
+
+### Performance
+- Discover 100+ hosts in under 30 seconds.
+- Convert schemas in under 100ms per tool for typical configurations.
+- Maintain memory usage below 50MB during typical operations.
+
+### Quality
+- Achieve 95%+ test coverage for core logic using `pytest` and `pytest-asyncio`.
+- Ensure full compliance with OAuth_LIGHTBOX2.1 and PKCE standards.
+- Provide comprehensive documentation (e.g., README, architecture guides) and structured logging via `structlog`.
+
+## Timeline Estimate
+- **MVP (P0)**: 3-4 weeks (core discovery, authentication, basic conversion).
+- **Feature Complete**: 6-8 weeks (full feature set, testing, optimization).
+- **Production Ready**: 10-12 weeks (deployment, monitoring, security hardening).
+
+## Implementation Considerations
+- **Schema Validation**: Validate MCP schemas and generated CRDs at each conversion step.
+- **Error Handling**: Handle invalid MCP specs, name conflicts, and transport errors gracefully.
+- **Testing**: Include unit tests, integration tests with mock MCP servers, and end-to-end tests in Kubernetes.
+- **Security**: Encrypt refresh tokens, restrict network scanning to allowed ranges, and follow OAuth best practices.
+
+This specification ensures MCP Vacuum aligns with the latest Kagent CRD schemas and provides a robust solution for integrating MCP servers and tools into Kagent workflows.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,49 @@
+# MCP Vacuum Documentation Index
+
+## Project Overview Documents
+- [MCP Vacuum Project Overview](mcpvacuum-MCP%20Vacuum%20Project%20Overview-260625-051824.pdf)
+- [Research Documentation: MCP Discovery & Kagent Integration](mcpvacuum-Research%20Documentation_%20MCP%20Discovery%20%26%20Kagent%20Integration-260625-051805.pdf)
+
+## Architecture Documentation
+- [MCP-Vacuum: Autodiscovery Agent Architecture](mcpvacuum-MCP-Vacuum_%20Autodiscovery%20Agent%20Architecture-260625-051759.pdf)
+- [MCP Server Autodiscovery & Kagent Integration Agent](mcpvacuum-MCP%20Server%20Autodiscovery%20%26%20Kagent%20Integration%20Agent-260625-051830.pdf)
+
+## Technical Component Guides
+- [Network Discovery Technical Guide](mcpvacuum-Network%20Discovery%20Technical%20Guide-260625-051812.pdf)
+- [Schema Conversion & Mapping Guide](mcpvacuum-Schema%20Conversion%20%26%20Mapping%20Guide-260625-051820.pdf)
+
+## Integration Guides
+- [Google ADK Integration Guide](mcpvacuum-Google%20ADK%20Integration%20Guide-260625-051808.pdf)
+- [OAuth 2.1 + PKCE Authentication Guide](mcpvacuum-OAuth%202.1%20%2B%20PKCE%20Authentication%20Guide-260625-051816.pdf)
+
+---
+
+# Documentation Summary Report
+
+## Overview
+The MCP Vacuum project documentation consists of 8 PDF documents covering various aspects of the system from high-level architecture to specific integration guides. The documentation is well-structured and covers key areas including project overview, architecture, technical components, and integration specifications.
+
+## Document Categories
+
+### Project Overview (2 documents)
+The project overview documents provide a comprehensive introduction to MCP Vacuum and include research findings regarding MCP Discovery and Kagent integration. These serve as essential starting points for understanding the project scope and objectives.
+
+### Architecture Documentation (2 documents)
+The architecture documentation focuses on the autodiscovery agent's design and its integration with MCP Server and Kagent. These documents outline the system's core architectural principles and components.
+
+### Technical Component Guides (2 documents)
+Technical guides cover specific implementation details for network discovery and schema conversion/mapping. These documents provide detailed technical specifications and implementation guidance for core system components.
+
+### Integration Guides (2 documents)
+Integration documentation includes guides for Google ADK integration and OAuth 2.1 authentication implementation. These documents provide detailed instructions for external system integration and security implementation.
+
+## Documentation Coverage Analysis
+- ✅ System Architecture
+- ✅ Authentication & Security
+- ✅ Integration Specifications
+- ✅ Technical Implementation
+- ✅ Network Discovery
+- ✅ Data Mapping & Schema Management
+
+## Documentation Management
+All documentation is maintained in PDF format in the `/docs` directory. The index.md file (this document) serves as a central reference point for accessing all project documentation.

--- a/docs/kagent_mcp_mapping.md
+++ b/docs/kagent_mcp_mapping.md
@@ -1,0 +1,243 @@
+# Kagent CRD Schemas and MCP Conversion Mapping
+
+## Overview
+
+This document outlines the Kagent CRD schemas for AI Tool-Servers and Tools, and provides a mapping strategy for converting MCP (Model Context Protocol) servers and tools into Kagent CRD format.
+
+## Kagent CRD Resources
+
+### 1. Agent CRD Schema
+
+```yaml
+apiVersion: kagent.dev/v1alpha1
+kind: Agent
+metadata:
+  name: <agent-name>
+  namespace: <namespace>
+spec:
+  description: <agent-description>
+  modelConfig: <model-config-name>
+  systemMessage: |
+    <system-prompt-instructions>
+  tools:
+    - type: McpServer
+      mcpServer:
+        toolServer: <toolserver-name>
+        toolNames:
+          - <tool-name-1>
+          - <tool-name-2>
+    - builtin:
+        name: <builtin-tool-name>
+        type: Builtin
+```
+
+### 2. ToolServer CRD Schema
+
+```yaml
+apiVersion: kagent.dev/v1alpha1
+kind: ToolServer
+metadata:
+  name: <toolserver-name>
+  namespace: <namespace>
+spec:
+  description: <toolserver-description>
+  config:
+    sse:
+      url: <mcp-server-url>
+    # Alternative configurations:
+    # stdio: {}
+    # websocket:
+    #   url: <websocket-url>
+```
+
+### 3. ModelConfig CRD Schema
+
+```yaml
+apiVersion: kagent.dev/v1alpha1
+kind: ModelConfig
+metadata:
+  name: <model-config-name>
+  namespace: <namespace>
+spec:
+  provider: <provider-name>  # openai, anthropic, etc.
+  model: <model-name>
+  # Additional provider-specific configuration
+```
+
+## MCP Protocol Schema Structure
+
+### MCP Server Schema
+```json
+{
+  "server": {
+    "name": "server-name",
+    "version": "1.0.0"
+  },
+  "capabilities": {
+    "tools": {},
+    "resources": {},
+    "prompts": {}
+  },
+  "tools": [
+    {
+      "name": "tool-name",
+      "description": "tool description",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "param1": {
+            "type": "string",
+            "description": "parameter description"
+          }
+        },
+        "required": ["param1"]
+      }
+    }
+  ]
+}
+```
+
+### MCP Tool Schema
+```json
+{
+  "name": "tool-name",
+  "description": "Tool description",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "parameter_name": {
+        "type": "string|number|boolean|array|object",
+        "description": "Parameter description",
+        "enum": ["option1", "option2"] // optional
+      }
+    },
+    "required": ["required_param"]
+  }
+}
+```
+
+## Conversion Mapping Strategy
+
+### MCP Server → Kagent ToolServer
+
+| MCP Field | Kagent Field | Transformation |
+|-----------|--------------|----------------|
+| `server.name` | `metadata.name` | Direct mapping, lowercase, kubernetes-safe |
+| `server.version` | `metadata.labels["version"]` | Add as label |
+| `server.description` | `spec.description` | Direct mapping |
+| Server URL/Connection | `spec.config.sse.url` | Based on transport type |
+| `capabilities.tools` | Implicit | Tools discovered at runtime |
+
+### MCP Tool → Kagent Agent Tool Reference
+
+| MCP Field | Kagent Field | Transformation |
+|-----------|--------------|----------------|
+| `tool.name` | `tools[].mcpServer.toolNames[]` | Array of tool names |
+| `tool.description` | N/A | Discovered at runtime |
+| `tool.inputSchema` | N/A | Discovered at runtime |
+
+## Implementation Strategy
+
+### 1. Schema Parsing Architecture
+
+```python
+# Core components for parsing and conversion
+class MCPServerParser:
+    """Parses MCP server specifications"""
+    
+class MCPToolParser:
+    """Parses individual MCP tool specifications"""
+    
+class KagentCRDGenerator:
+    """Generates Kagent CRD YAML from parsed MCP data"""
+    
+class ConversionPipeline:
+    """Orchestrates the conversion process"""
+```
+
+### 2. Conversion Pipeline
+
+```mermaid
+graph LR
+    A[MCP Server Spec] --> B[Parse MCP Schema]
+    B --> C[Validate MCP Structure]
+    C --> D[Map to Kagent CRD]
+    D --> E[Generate ToolServer CRD]
+    E --> F[Generate Agent CRD Template]
+    F --> G[Output Kubernetes YAML]
+```
+
+### 3. Key Conversion Rules
+
+#### ToolServer Conversion
+- **Name**: MCP server name → Kubernetes-compliant name (lowercase, no spaces)
+- **Description**: Direct mapping from MCP server description
+- **Config**: Map MCP transport configuration to Kagent config format
+- **Tools**: Tools are discovered dynamically, not statically defined
+
+#### Agent Tool Reference
+- **Tool Names**: Extract from MCP server's tool list
+- **Tool Server Reference**: Link to generated ToolServer CRD
+- **Type**: Always "McpServer" for MCP-based tools
+
+### 4. Transport Mapping
+
+| MCP Transport | Kagent Config |
+|---------------|---------------|
+| SSE (Server-Sent Events) | `config.sse.url` |
+| WebSocket | `config.websocket.url` |
+| STDIO | `config.stdio: {}` |
+
+### 5. Metadata Enrichment
+
+```yaml
+# Additional metadata for tracking conversion
+metadata:
+  labels:
+    mcp.source: "converted"
+    mcp.server.name: <original-mcp-name>
+    mcp.server.version: <original-version>
+  annotations:
+    mcp.conversion.timestamp: <conversion-time>
+    mcp.original.spec: <base64-encoded-original-spec>
+```
+
+## Implementation Considerations
+
+### 1. Schema Validation
+- Validate MCP server specifications against MCP protocol schema
+- Ensure generated Kagent CRDs are valid Kubernetes resources
+- Handle edge cases in naming and field mappings
+
+### 2. Tool Discovery
+- Kagent discovers tools at runtime from MCP servers
+- Tool schemas are not statically defined in CRDs
+- Conversion tool should validate tool availability
+
+### 3. Namespace Management
+- Default to a specific namespace for converted resources
+- Allow namespace override for multi-tenant scenarios
+- Ensure proper RBAC for resource creation
+
+### 4. Error Handling
+- Invalid MCP specifications
+- Kubernetes name conflicts
+- Missing required fields
+- Transport configuration errors
+
+### 5. Testing Strategy
+- Unit tests for each conversion component
+- Integration tests with sample MCP servers
+- Validation tests for generated CRDs
+- End-to-end tests in Kubernetes environment
+
+## Next Steps
+
+1. **Locate Official Schemas**: Find the complete Kagent CRD schemas in the GitHub repository
+2. **Develop Parser**: Create robust MCP specification parser
+3. **Build Converter**: Implement the conversion logic
+4. **Create CLI Tool**: Build user-friendly conversion tool
+5. **Add Validation**: Implement comprehensive validation
+6. **Test Integration**: Validate with real MCP servers
+
+This mapping provides a solid foundation for converting MCP servers and tools into Kagent CRD format while maintaining compatibility and functionality.

--- a/tests/test_platform_compatibility.py
+++ b/tests/test_platform_compatibility.py
@@ -1,0 +1,135 @@
+import pytest
+import platform
+import asyncio
+import docker
+import keyring
+from unittest.mock import patch, MagicMock
+import logging
+
+logger = logging.getLogger(__name__)
+
+@pytest.fixture
+async def mock_docker_client():
+    async with MagicMock(spec=docker.DockerClient) as mock_client:
+        yield mock_client
+
+@pytest.fixture
+def mock_keyring():
+    with patch('keyring.get_keyring') as mock:
+        mock_ring = MagicMock()
+        mock.return_value = mock_ring
+        yield mock_ring
+
+@pytest.fixture
+def mock_network_discovery():
+    with patch('socket.socket') as mock_socket:
+        mock_socket.return_value.getsockname.return_value = ('127.0.0.1', 12345)
+        yield mock_socket
+
+@pytest.mark.parametrize("platform", ["windows", "linux"])
+async def test_platform_compatibility(platform, mock_docker_client, mock_keyring, mock_network_discovery):
+    """Test platform-specific functionality across different components."""
+    
+    # Setup platform-specific environment
+    with patch('platform.system', return_value=platform.capitalize()):
+        # Test keyring functionality
+        await test_keyring_operations(mock_keyring, platform)
+        
+        # Test network discovery
+        await test_network_discovery(mock_network_discovery, platform)
+        
+        # Test Docker integration
+        await test_docker_integration(mock_docker_client, platform)
+        
+        # Test development tools
+        await test_development_tools(platform)
+
+async def test_keyring_operations(mock_keyring, platform):
+    """Test platform-specific keyring functionality."""
+    logger.info(f"Testing keyring operations on {platform}")
+    
+    test_service = "mcp-vacuum"
+    test_username = "test_user"
+    test_password = "test_password"
+    
+    # Test storing credentials
+    mock_keyring.set_password(test_service, test_username, test_password)
+    mock_keyring.set_password.assert_called_once_with(test_service, test_username, test_password)
+    
+    # Test retrieving credentials
+    mock_keyring.get_password.return_value = test_password
+    retrieved_password = mock_keyring.get_password(test_service, test_username)
+    assert retrieved_password == test_password
+    
+    # Test credential deletion
+    mock_keyring.delete_password(test_service, test_username)
+    mock_keyring.delete_password.assert_called_once_with(test_service, test_username)
+
+async def test_network_discovery(mock_network_discovery, platform):
+    """Test platform-specific network discovery functionality."""
+    logger.info(f"Testing network discovery on {platform}")
+    
+    # Test port availability check
+    mock_network_discovery.return_value.bind.return_value = None
+    mock_network_discovery.return_value.getsockname.return_value = ('127.0.0.1', 12345)
+    
+    # Verify socket creation
+    assert mock_network_discovery.called
+    
+    # Test network interface enumeration
+    with patch('netifaces.interfaces') as mock_interfaces:
+        mock_interfaces.return_value = ['eth0', 'lo']
+        interfaces = mock_interfaces()
+        assert 'eth0' in interfaces
+        assert 'lo' in interfaces
+
+async def test_docker_integration(mock_docker_client, platform):
+    """Test platform-specific Docker integration."""
+    logger.info(f"Testing Docker integration on {platform}")
+    
+    # Test Docker connection
+    mock_docker_client.ping.return_value = True
+    assert await mock_docker_client.ping()
+    
+    # Test container operations
+    mock_container = MagicMock()
+    mock_docker_client.containers.run.return_value = mock_container
+    
+    container_config = {
+        'image': 'test-image:latest',
+        'command': 'echo "test"',
+        'environment': {'PLATFORM': platform}
+    }
+    
+    await mock_docker_client.containers.run(**container_config)
+    mock_docker_client.containers.run.assert_called_once_with(**container_config)
+
+async def test_development_tools(platform):
+    """Test platform-specific development tools."""
+    logger.info(f"Testing development tools on {platform}")
+    
+    # Test Python environment
+    assert platform.system() in ['Windows', 'Linux']
+    
+    # Test async functionality
+    async def async_operation():
+        await asyncio.sleep(0)
+        return True
+    
+    result = await async_operation()
+    assert result is True
+    
+    # Test logging configuration
+    assert logger.name == __name__
+    
+    # Test platform-specific path handling
+    with patch('os.path') as mock_path:
+        if platform.lower() == 'windows':
+            mock_path.sep = '\\'
+            mock_path.join.return_value = 'C:\\test\\path'
+        else:
+            mock_path.sep = '/'
+            mock_path.join.return_value = '/test/path'
+            
+        test_path = mock_path.join('test', 'path')
+        assert mock_path.sep in test_path


### PR DESCRIPTION
## Changes
- Remove .local and .metadata directories
- Update .gitignore to reference mcp-vacuum-internal
- Clean up local tracking files after successful migration

### Notes
- All internal documentation and tracking has been migrated to private mcp-vacuum-internal repository
- Updated .gitignore to prevent future local tracking files from being committed
- Maintains clean separation between public and private project information

### Related Changes
- Internal documentation now lives in tzervas/mcp-vacuum-internal
- All tracking and metadata is now centrally managed