### PR TITLE
fix: update model definitions and type hints

### DIFF
--- a/src/mcp_vacuum/mcp_client/exceptions.py
+++ b/src/mcp_vacuum/mcp_client/exceptions.py
@@ -1,6 +1,7 @@
 """
 Custom exceptions for the MCP client.
 """
+from typing import Any, Dict, Optional
 
 class MCPClientError(Exception):
     """Base class for all MCP client errors."""
@@ -17,7 +18,7 @@ class MCPTimeoutError(MCPConnectionError):
 class MCPProtocolError(MCPClientError):
     """Raised for errors related to the JSONRPC protocol itself
     (e.g., malformed responses, unexpected message format)."""
-    def __init__(self, message: str, error_code: int | None = None, error_data: dict | None = None):
+    def __init__(self, message: str, error_code: Optional[int] = None, error_data: Optional[Dict] = None):
         super().__init__(message)
         self.error_code = error_code
         self.error_data = error_data
@@ -25,7 +26,7 @@ class MCPProtocolError(MCPClientError):
 class MCPToolInvocationError(MCPClientError):
     """Raised when invoking a tool on the MCP server results in an error
     reported by the server's JSONRPC error response for that tool call."""
-    def __init__(self, tool_name: str, message: str, error_code: int | None = None, error_data: dict | None = None):
+    def __init__(self, tool_name: str, message: str, error_code: Optional[int] = None, error_data: Optional[Dict] = None):
         full_message = f"Error invoking tool '{tool_name}': {message}"
         super().__init__(full_message)
         self.tool_name = tool_name
@@ -35,7 +36,7 @@ class MCPToolInvocationError(MCPClientError):
 
 class MCPAuthError(MCPClientError):
     """Raised for authentication specific errors during MCP communication."""
-    def __init__(self, message: str, server_error: Any | None = None, requires_reauth: bool = False):
+    def __init__(self, message: str, server_error: Optional[Any] = None, requires_reauth: bool = False):
         super().__init__(message)
         self.server_error = server_error
         self.requires_reauth = requires_reauth

--- a/src/mcp_vacuum/models/kagent.py
+++ b/src/mcp_vacuum/models/kagent.py
@@ -1,12 +1,10 @@
-"""
 """Module for Kagent-related models and schema validation."""
-import datetime
+from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, validator
 from .common import ToolCategory, RiskLevel, BasePydanticModel, KagentCRDSchema
-
 
 class ValidationSeverity(str, Enum):
     """Schema validation issue severity levels."""
@@ -14,26 +12,23 @@ class ValidationSeverity(str, Enum):
     WARNING = "warning"
     INFO = "info"
 
-
 class ValidationIssue(BasePydanticModel):
     """Represents a validation issue found during schema conversion."""
     severity: ValidationSeverity
     message: str
-    path: str | None = None
-    details: dict[str, Any] | None = None
-    field_path: str | None = None  # For backward compatibility
-
+    path: Optional[str] = None
+    details: Optional[Dict[str, Any]] = None
+    field_path: Optional[str] = None  # For backward compatibility
 
 class ValidationResult(BasePydanticModel):
     """Results of schema validation."""
     is_valid: bool
-    issues: list[ValidationIssue] = Field(default_factory=list)
+    issues: List[ValidationIssue] = Field(default_factory=list)
 
     @property
     def has_errors(self) -> bool:
         """Check if there are any error-level issues."""
         return any(issue.severity == ValidationSeverity.ERROR for issue in self.issues)
-
 
 class KagentMetadata(BasePydanticModel):
     """Metadata for Kagent tool definitions."""
@@ -41,105 +36,48 @@ class KagentMetadata(BasePydanticModel):
     version: str
     category: ToolCategory
     risk_level: RiskLevel
-    description: str | None = None
-    labels: dict[str, str] = Field(default_factory=dict)
-    annotations: dict[str, str] = Field(default_factory=dict)
-
+    description: Optional[str] = None
+    labels: Dict[str, str] = Field(default_factory=dict)
+    annotations: Dict[str, str] = Field(default_factory=dict)
 
 class KagentToolSpec(BasePydanticModel):
     """Specification for a Kagent tool."""
     description: str
     parameters: KagentCRDSchema
-    outputs: KagentCRDSchema | None = None
+    outputs: Optional[KagentCRDSchema] = None
     metadata: KagentMetadata
-    examples: list[dict[str, Any]] = Field(default_factory=list)
-    validation_rules: dict[str, Any] | None = None
-
+    examples: List[Dict[str, Any]] = Field(default_factory=list)
+    validation_rules: Optional[Dict[str, Any]] = None
 
 class KagentTool(BasePydanticModel):
-    """Root model for a Kagent tool definition."""
-    apiVersion: str = Field(pattern=r"^kagent\.ai/v1(alpha\d+|beta\d+)?$")
-    kind: str = Field(default="Tool")
-    metadata: KagentMetadata
-    spec: KagentToolSpec
-
-    @field_validator("kind")
-    @classmethod
-    def validate_kind(cls, v: str) -> str:
-        """Validate 'kind' field."""
-        if v != "Tool":
-            raise ValueError("kind must be 'Tool'")
-        return v
-
-
-class ConversionMetadataModel(BasePydanticModel):
-    """Metadata about the conversion process."""
-    source_schema_version: str
-    source_system: str
-    conversion_timestamp: str
-    validation_result: ValidationResult | None = None
-    original_tool_name: str
-    conversion_version: str
-    semantic_score: float = Field(ge=0, le=1)
-    field_mappings: dict[str, str] = Field(default_factory=dict)
-
-
-class ConversionResult(BasePydanticModel):
-    """Results of converting an MCP tool to Kagent format."""
-    tool: KagentTool
-    metadata: ConversionMetadataModel
-    original_schema: dict[str, Any]  # The original MCP schema
-    Represents a Kagent tool definition.
+    """Root model for a Kagent tool definition.
     Based on Kubernetes-style resource definition.
     """
-    api_version: str = Field(default="tools.kagent.ai/v1")
-=======
-    parameters: KagentCRDSchema
-    outputs: KagentCRDSchema | None = None
-    metadata: KagentMetadata
-    examples: list[dict[str, Any]] = Field(default_factory=list)
-    validation_rules: dict[str, Any] | None = None
-
-
-class KagentTool(BasePydanticModel):
-    """Root model for a Kagent tool definition."""
     apiVersion: str = Field(pattern=r"^kagent\.ai/v1(alpha\d+|beta\d+)?$")
->>>>>>> main
     kind: str = Field(default="Tool")
     metadata: KagentMetadata
     spec: KagentToolSpec
 
-<<<<<<< HEAD
-
-class ConversionMetadataModel(BasePydanticModel):
-    """Metadata about the tool conversion process."""
-    original_tool_name: str
-    conversion_timestamp: datetime.datetime
-    conversion_version: str
-    semantic_score: float = Field(ge=0, le=1)
-    validation_results: ValidationResult
-    field_mappings: dict[str, str] = Field(default_factory=dict)
-=======
-    @field_validator("kind")
-    @classmethod
+    @validator("kind")
     def validate_kind(cls, v: str) -> str:
         """Validate 'kind' field."""
         if v != "Tool":
             raise ValueError("kind must be 'Tool'")
         return v
 
-
 class ConversionMetadataModel(BasePydanticModel):
     """Metadata about the conversion process."""
     source_schema_version: str
     source_system: str
     conversion_timestamp: str
-    validation_result: ValidationResult | None = None
-
+    validation_result: Optional[ValidationResult] = None
+    original_tool_name: str
+    conversion_version: str
+    semantic_score: float = Field(ge=0, le=1)
+    field_mappings: Dict[str, str] = Field(default_factory=dict)
 
 class ConversionResult(BasePydanticModel):
     """Results of converting an MCP tool to Kagent format."""
     tool: KagentTool
     metadata: ConversionMetadataModel
-    original_schema: dict[str, Any]  # The original MCP schema
->>>>>>> main
+    original_schema: Dict[str, Any]  # The original MCP schema


### PR DESCRIPTION
## Changes
- Removed merge conflict markers from model files
- Updated type hint syntax for better compatibility
- Fixed Pydantic v1 compatibility issues
- Improved model structure and documentation

## Testing
- All model-related tests pass
- Type checking passes
- No merge conflicts remain

## Related Issues
- Addresses model syntax and type hint inconsistencies
- Improves code maintainability

## Summary by Sourcery

Unify type hints across models and exceptions, restore Pydantic v1 compatibility by replacing field validators and updating imports, and clean up merge conflict artifacts.

Bug Fixes:
- Remove leftover merge conflict markers from model files

Enhancements:
- Standardize type annotations to use Optional, List, and Dict for broader compatibility
- Replace Pydantic v2-specific field_validator with validator and refine imports
- Enhance model and exception docstrings and streamline schema definitions

Documentation:
- Improve inline documentation on core model classes