### PR TITLE
refactor: improve type hints and use datetime for timestamps

### DIFF
--- a/src/mcp_vacuum/models/kagent.py
+++ b/src/mcp_vacuum/models/kagent.py
@@ -69,7 +69,7 @@ class ConversionMetadataModel(BasePydanticModel):
     """Metadata about the conversion process."""
     source_schema_version: str
     source_system: str
-    conversion_timestamp: str
+    conversion_timestamp: datetime
     validation_result: Optional[ValidationResult] = None
     original_tool_name: str
     conversion_version: str


### PR DESCRIPTION
Addresses code review feedback:

- Updates conversion_timestamp to use datetime type in ConversionMetadataModel for better type safety and validation
- Verified that details field already has proper Dict[str, Any] typing
- Verified no merge conflict markers present in code

## Summary by Sourcery

Enhancements:
- Change conversion_timestamp field type from str to datetime for improved type safety