### PR TITLE
ci: convert workflows to workflow_dispatch-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,8 @@
 name: Python CI
 
+# Manual only — no push/pull_request CI triggers
 on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
-  workflow_dispatch: # Allows manual triggering
-
+  workflow_dispatch:
 jobs:
   build-and-test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Removes automatic push/pull_request/schedule CI triggers. Use workflow_dispatch to run CI manually.